### PR TITLE
Review resource and gRPC planning document

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -65,6 +65,10 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreateImage(msg)
 	case "updateImage":
 		b.handleUpdateImage(msg)
+	case "registerResource":
+		b.handleRegisterResource(msg)
+	case "unregisterResource":
+		b.handleUnregisterResource(msg)
 	case "createBorder":
 		b.handleCreateBorder(msg)
 	case "createGridWrap":

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -52,6 +52,7 @@ type Bridge struct {
 	customIds      map[string]string                // custom ID -> widget ID (for test framework)
 	childToParent map[string]string              // child ID -> parent ID
 	quitChan      chan bool                      // signal quit in test mode
+	resources     map[string][]byte              // resource name -> decoded image data
 }
 
 // WidgetMetadata stores metadata about widgets for testing
@@ -205,6 +206,7 @@ func NewBridge(testMode bool) *Bridge {
 		customIds:      make(map[string]string),
 		childToParent: make(map[string]string),
 		quitChan:      make(chan bool, 1),
+		resources:     make(map[string][]byte),
 	}
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { Context } from './context';
 import { Window, WindowOptions } from './window';
 import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap } from './widgets';
 import { initializeGlobals } from './globals';
+import { ResourceManager } from './resources';
 
 export interface AppOptions {
   title?: string;
@@ -15,6 +16,7 @@ export class App {
   private ctx: Context;
   private windows: Window[] = [];
   private bridge: BridgeConnection;
+  public resources: ResourceManager;
 
   constructor(options?: AppOptions, testMode: boolean = false) {
     // Initialize browser compatibility globals
@@ -22,6 +24,7 @@ export class App {
 
     this.bridge = new BridgeConnection(testMode);
     this.ctx = new Context(this.bridge);
+    this.resources = new ResourceManager(this.bridge);
   }
 
   getContext(): Context {
@@ -156,13 +159,13 @@ export class App {
   }
 
   image(
-    path: string,
+    pathOrOptions: string | { path?: string; resource?: string; fillMode?: 'contain' | 'stretch' | 'original'; onClick?: () => void; onDrag?: (x: number, y: number) => void; onDragEnd?: (x: number, y: number) => void; },
     fillMode?: 'contain' | 'stretch' | 'original',
     onClick?: () => void,
     onDrag?: (x: number, y: number) => void,
     onDragEnd?: (x: number, y: number) => void
   ): Image {
-    return new Image(this.ctx, path, fillMode, onClick, onDrag, onDragEnd);
+    return new Image(this.ctx, pathOrOptions, fillMode, onClick, onDrag, onDragEnd);
   }
 
   border(config: { top?: () => void; bottom?: () => void; left?: () => void; right?: () => void; center?: () => void; }): Border {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,0 +1,78 @@
+import type { FyneBridge } from './fynebridge';
+
+/**
+ * Manages reusable image resources to reduce data transfer
+ * Resources are registered once on the Go/Fyne side and can be referenced multiple times
+ */
+export class ResourceManager {
+  private bridge: FyneBridge;
+  private registeredResources: Set<string> = new Set();
+
+  constructor(bridge: FyneBridge) {
+    this.bridge = bridge;
+  }
+
+  /**
+   * Register a reusable image resource
+   * @param name - Unique resource name (e.g., "chess-light-square", "chess-piece-white-king")
+   * @param data - Base64 encoded image data (with or without data URI prefix)
+   * @returns Promise that resolves when the resource is registered
+   */
+  async registerResource(name: string, data: string): Promise<void> {
+    if (this.registeredResources.has(name)) {
+      throw new Error(`Resource already registered: ${name}`);
+    }
+
+    await this.bridge.send('registerResource', {
+      name,
+      data
+    });
+
+    this.registeredResources.add(name);
+  }
+
+  /**
+   * Unregister a resource to free memory on the Go/Fyne side
+   * @param name - Resource name to unregister
+   * @returns Promise that resolves when the resource is unregistered
+   */
+  async unregisterResource(name: string): Promise<void> {
+    if (!this.registeredResources.has(name)) {
+      return; // Already unregistered or never registered
+    }
+
+    await this.bridge.send('unregisterResource', {
+      name
+    });
+
+    this.registeredResources.delete(name);
+  }
+
+  /**
+   * Check if a resource is registered
+   * @param name - Resource name to check
+   * @returns true if the resource is registered, false otherwise
+   */
+  isRegistered(name: string): boolean {
+    return this.registeredResources.has(name);
+  }
+
+  /**
+   * Get all registered resource names
+   * @returns Array of registered resource names
+   */
+  getRegisteredResources(): string[] {
+    return Array.from(this.registeredResources);
+  }
+
+  /**
+   * Unregister all resources
+   * @returns Promise that resolves when all resources are unregistered
+   */
+  async unregisterAll(): Promise<void> {
+    const resources = Array.from(this.registeredResources);
+    for (const name of resources) {
+      await this.unregisterResource(name);
+    }
+  }
+}


### PR DESCRIPTION
Implemented Phase 1 of the resource_and_grpc_plan.md:
- Added resource management to Go/Fyne bridge
- Created ResourceManager class in TypeScript
- Modified Image widget to support resource references
- Updated chess app to use resource registration

Changes:
- bridge/resources.go: New resource management handlers
- bridge/types.go: Added resources map to Bridge struct
- bridge/widget_creators.go: Support resource references in createImage
- bridge/main.go: Register resource handlers
- src/resources.ts: New ResourceManager class
- src/app.ts: Add resources property to App
- src/widgets.ts: Update Image to accept resource parameter
- examples/chess/chess.ts: Register chess resources at startup

Benefits:
- Empty chess squares now use shared resources
- Reduces data transfer by eliminating redundant image data
- Foundation for further optimizations