### PR TITLE
Add editable grid column properties to designer

### DIFF
--- a/designer/public/index.html
+++ b/designer/public/index.html
@@ -318,6 +318,70 @@
       align-items: center;
       gap: 10px;
     }
+
+    /* Context Menu Styles */
+    .context-menu {
+      position: fixed;
+      background: #3c3c3c;
+      border: 1px solid #5e5e5e;
+      border-radius: 3px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+      padding: 4px 0;
+      z-index: 1000;
+      display: none;
+      min-width: 180px;
+    }
+
+    .context-menu.visible {
+      display: block;
+    }
+
+    .context-menu-item {
+      padding: 6px 12px;
+      cursor: pointer;
+      font-size: 12px;
+      color: #d4d4d4;
+      white-space: nowrap;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .context-menu-item:hover {
+      background: #094771;
+    }
+
+    .context-menu-separator {
+      height: 1px;
+      background: #5e5e5e;
+      margin: 4px 0;
+    }
+
+    .context-menu-submenu {
+      position: relative;
+    }
+
+    .context-menu-submenu-arrow {
+      margin-left: auto;
+      font-size: 10px;
+    }
+
+    .context-submenu {
+      position: absolute;
+      left: 100%;
+      top: 0;
+      background: #3c3c3c;
+      border: 1px solid #5e5e5e;
+      border-radius: 3px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+      padding: 4px 0;
+      display: none;
+      min-width: 120px;
+    }
+
+    .context-menu-submenu:hover .context-submenu {
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -374,6 +438,9 @@
       </div>
     </div>
   </div>
+
+  <!-- Context Menu -->
+  <div id="contextMenu" class="context-menu"></div>
 
   <script src="editor.js"></script>
 </body>


### PR DESCRIPTION
…rties

Adds right-click context menu to tree outline that allows quick editing of:
- Grid columns (with quick presets 1-6 or custom value)
- GridWrap itemWidth and itemHeight
- Split offset (for hsplit/vsplit)

Properties panel editing was already functional for these properties. The context menu provides a faster workflow for common adjustments.

Changes:
- Add context menu CSS styling to index.html
- Implement context menu logic in editor.js with widget-specific options
- Add comprehensive Jest tests for property editing via API
- All standalone unit tests passing (15/15)

Tests verify:
- Grid column editing through multiple values (simulating context menu)
- GridWrap property editing (itemWidth, itemHeight)
- Numeric property validation
- API integration for property updates