### PR TITLE
Design bridge-inspired logo for Tsyne

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# Tsyne
+<p align="center">
+  <img src="logo-full.svg" alt="Tsyne Logo" width="300">
+</p>
 
-**Elegant TypeScript wrapper for Fyne - Build beautiful cross-platform desktop UIs with Node.js**
+<p align="center">
+  <strong>Elegant TypeScript wrapper for Fyne - Build beautiful cross-platform desktop UIs with Node.js</strong>
+</p>
+
+<p align="center">
+  <em>Bridging TypeScript and Go, inspired by the bridges over the River Tyne</em>
+</p>
+
+---
 
 Tsyne brings the power of [Fyne](https://fyne.io/), a modern Go UI toolkit, to the TypeScript/Node.js ecosystem with an elegant, pseudo-declarative API inspired by Ruby's Shoes DSL and QML.
 

--- a/logo-full.svg
+++ b/logo-full.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 160" width="200" height="160">
+  <!-- Tsyne Bridge Logo with Text - Inspired by the Tyne Bridge -->
+  <defs>
+    <!-- Gradient for the main arch -->
+    <linearGradient id="archGradientFull" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3178C6" /> <!-- TypeScript blue -->
+      <stop offset="50%" style="stop-color:#00ADD8" /> <!-- Go cyan -->
+      <stop offset="100%" style="stop-color:#3178C6" /> <!-- TypeScript blue -->
+    </linearGradient>
+    <!-- Gradient for towers -->
+    <linearGradient id="towerGradientFull" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#2D5A8A" />
+      <stop offset="100%" style="stop-color:#4A90C2" />
+    </linearGradient>
+    <!-- Text gradient -->
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3178C6" />
+      <stop offset="100%" style="stop-color:#00ADD8" />
+    </linearGradient>
+  </defs>
+
+  <!-- Water reflection effect -->
+  <ellipse cx="100" cy="100" rx="85" ry="8" fill="#1a365d" opacity="0.3"/>
+
+  <!-- Main arch - iconic Tyne Bridge shape -->
+  <path d="M 20,80
+           Q 20,25 100,20
+           Q 180,25 180,80"
+        fill="none"
+        stroke="url(#archGradientFull)"
+        stroke-width="8"
+        stroke-linecap="round"/>
+
+  <!-- Secondary inner arch for depth -->
+  <path d="M 30,80
+           Q 30,35 100,30
+           Q 170,35 170,80"
+        fill="none"
+        stroke="url(#archGradientFull)"
+        stroke-width="3"
+        stroke-linecap="round"
+        opacity="0.5"/>
+
+  <!-- Left tower (Art Deco style) -->
+  <rect x="12" y="50" width="16" height="35" rx="2" fill="url(#towerGradientFull)"/>
+  <rect x="14" y="45" width="12" height="8" rx="1" fill="url(#towerGradientFull)"/>
+  <rect x="16" y="40" width="8" height="7" rx="1" fill="#3178C6"/>
+
+  <!-- Right tower (Art Deco style) -->
+  <rect x="172" y="50" width="16" height="35" rx="2" fill="url(#towerGradientFull)"/>
+  <rect x="174" y="45" width="12" height="8" rx="1" fill="url(#towerGradientFull)"/>
+  <rect x="176" y="40" width="8" height="7" rx="1" fill="#00ADD8"/>
+
+  <!-- Road deck -->
+  <rect x="20" y="78" width="160" height="6" rx="1" fill="#4A5568"/>
+
+  <!-- Suspension cables from arch to deck -->
+  <g stroke="#5A8BC2" stroke-width="1.5" opacity="0.7">
+    <line x1="40" y1="45" x2="40" y2="78"/>
+    <line x1="60" y1="33" x2="60" y2="78"/>
+    <line x1="80" y1="27" x2="80" y2="78"/>
+    <line x1="100" y1="24" x2="100" y2="78"/>
+    <line x1="120" y1="27" x2="120" y2="78"/>
+    <line x1="140" y1="33" x2="140" y2="78"/>
+    <line x1="160" y1="45" x2="160" y2="78"/>
+  </g>
+
+  <!-- Small decorative elements on towers -->
+  <circle cx="20" cy="55" r="2" fill="#fff" opacity="0.6"/>
+  <circle cx="180" cy="55" r="2" fill="#fff" opacity="0.6"/>
+
+  <!-- TSYNE text -->
+  <text x="100" y="135"
+        font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+        font-size="32"
+        font-weight="700"
+        letter-spacing="6"
+        text-anchor="middle"
+        fill="url(#textGradient)">TSYNE</text>
+
+  <!-- Tagline -->
+  <text x="100" y="152"
+        font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+        font-size="9"
+        font-weight="400"
+        letter-spacing="2"
+        text-anchor="middle"
+        fill="#718096">TYPESCRIPT + FYNE</text>
+</svg>

--- a/logo-icon.svg
+++ b/logo-icon.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- Tsyne Bridge Icon - Minimal version for small sizes -->
+  <defs>
+    <linearGradient id="iconGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3178C6" /> <!-- TypeScript blue -->
+      <stop offset="50%" style="stop-color:#00ADD8" /> <!-- Go cyan -->
+      <stop offset="100%" style="stop-color:#3178C6" /> <!-- TypeScript blue -->
+    </linearGradient>
+  </defs>
+
+  <!-- Background circle (optional - remove for transparent) -->
+  <!-- <circle cx="32" cy="32" r="30" fill="#1a202c"/> -->
+
+  <!-- Main arch -->
+  <path d="M 8,48
+           Q 8,14 32,10
+           Q 56,14 56,48"
+        fill="none"
+        stroke="url(#iconGradient)"
+        stroke-width="5"
+        stroke-linecap="round"/>
+
+  <!-- Left tower -->
+  <rect x="4" y="35" width="8" height="18" rx="1" fill="#3178C6"/>
+  <rect x="5" y="31" width="6" height="5" rx="1" fill="#4A90C2"/>
+
+  <!-- Right tower -->
+  <rect x="52" y="35" width="8" height="18" rx="1" fill="#00ADD8"/>
+  <rect x="53" y="31" width="6" height="5" rx="1" fill="#00C4E8"/>
+
+  <!-- Road deck -->
+  <rect x="8" y="48" width="48" height="4" rx="1" fill="#4A5568"/>
+
+  <!-- Center suspension cable -->
+  <line x1="32" y1="14" x2="32" y2="48" stroke="#5A8BC2" stroke-width="2" opacity="0.7"/>
+</svg>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120" width="200" height="120">
+  <!-- Tsyne Bridge Logo - Inspired by the Tyne Bridge -->
+  <defs>
+    <!-- Gradient for the main arch -->
+    <linearGradient id="archGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3178C6;stop-opacity:1" /> <!-- TypeScript blue -->
+      <stop offset="50%" style="stop-color:#00ADD8;stop-opacity:1" /> <!-- Go cyan -->
+      <stop offset="100%" style="stop-color:#3178C6;stop-opacity:1" /> <!-- TypeScript blue -->
+    </linearGradient>
+    <!-- Gradient for towers -->
+    <linearGradient id="towerGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#2D5A8A;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4A90C2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Water reflection effect -->
+  <ellipse cx="100" cy="105" rx="85" ry="8" fill="#1a365d" opacity="0.3"/>
+
+  <!-- Main arch - iconic Tyne Bridge shape -->
+  <path d="M 20,85
+           Q 20,30 100,25
+           Q 180,30 180,85"
+        fill="none"
+        stroke="url(#archGradient)"
+        stroke-width="8"
+        stroke-linecap="round"/>
+
+  <!-- Secondary inner arch for depth -->
+  <path d="M 30,85
+           Q 30,40 100,35
+           Q 170,40 170,85"
+        fill="none"
+        stroke="url(#archGradient)"
+        stroke-width="3"
+        stroke-linecap="round"
+        opacity="0.5"/>
+
+  <!-- Left tower (Art Deco style) -->
+  <rect x="12" y="55" width="16" height="35" rx="2" fill="url(#towerGradient)"/>
+  <rect x="14" y="50" width="12" height="8" rx="1" fill="url(#towerGradient)"/>
+  <rect x="16" y="45" width="8" height="7" rx="1" fill="#3178C6"/>
+
+  <!-- Right tower (Art Deco style) -->
+  <rect x="172" y="55" width="16" height="35" rx="2" fill="url(#towerGradient)"/>
+  <rect x="174" y="50" width="12" height="8" rx="1" fill="url(#towerGradient)"/>
+  <rect x="176" y="45" width="8" height="7" rx="1" fill="#00ADD8"/>
+
+  <!-- Road deck -->
+  <rect x="20" y="83" width="160" height="6" rx="1" fill="#4A5568"/>
+
+  <!-- Suspension cables from arch to deck -->
+  <g stroke="#5A8BC2" stroke-width="1.5" opacity="0.7">
+    <line x1="40" y1="50" x2="40" y2="83"/>
+    <line x1="60" y1="38" x2="60" y2="83"/>
+    <line x1="80" y1="32" x2="80" y2="83"/>
+    <line x1="100" y1="29" x2="100" y2="83"/>
+    <line x1="120" y1="32" x2="120" y2="83"/>
+    <line x1="140" y1="38" x2="140" y2="83"/>
+    <line x1="160" y1="50" x2="160" y2="83"/>
+  </g>
+
+  <!-- Small decorative elements on towers -->
+  <circle cx="20" cy="60" r="2" fill="#fff" opacity="0.6"/>
+  <circle cx="180" cy="60" r="2" fill="#fff" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
Create bridge logo inspired by the iconic Tyne Bridge, reflecting the project's name (Tsyne = Tyne) and core concept of bridging TypeScript and Go/Fyne. The logo uses TypeScript blue and Go cyan gradients to represent the two technologies being connected.

Logo variants:
- logo.svg: Full bridge illustration
- logo-icon.svg: Minimal icon version for small sizes
- logo-full.svg: Complete logo with TSYNE text and tagline