### PR TITLE
Add "Why Not Tsyne?" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Tsyne brings the power of [Fyne](https://fyne.io/), a modern Go UI toolkit, to t
 - **npm Ecosystem**: Use any of npm's 2M+ packages that don't require browser DOM - share validators, API clients, and business logic with your web apps
 - **Interpreted + Native**: TypeScript logic is interpreted for rapid iteration; rendering is compiled Go/Fyne for native performance (trade-off: requires Node.js runtime, not single binary distribution)
 
+## Why Not Tsyne?
+
+Tsyne isn't the right choice for every project. Consider these limitations:
+
+- **No Mobile Support**: Go+Fyne can target iOS and Android directly, but Tsyne requires Node.js runtime which isn't available on mobile platforms. If you need mobile, use Fyne directly in Go.
+- **Requires Node.js Runtime**: Pure Go/Fyne apps compile to single standalone binaries. Tsyne apps need Node.js installed, making distribution more complex.
+- **IPC Overhead**: The JSON-RPC bridge between TypeScript and Go adds latency compared to native Fyne. For performance-critical UIs with rapid updates, native Fyne may be better.
+- **Partial Fyne Coverage**: Tsyne wraps ~15% of Fyne's API (see [ROADMAP.md](docs/ROADMAP.md)). Advanced Fyne features like custom canvas drawing, animations, or specialized widgets may not be available.
+- **Fyne's Styling Limitations**: Per-widget color customization is limited by Fyne's architecture. Font styling works well, but colors require custom themes.
+
+**When to use Fyne directly instead:**
+- Mobile apps (iOS/Android)
+- Single-binary desktop distribution
+- Performance-critical real-time UIs
+- Full access to Fyne's complete widget library
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Provides honest limitations including:
- No mobile support (Go+Fyne can target iOS/Android, Tsyne cannot)
- Requires Node.js runtime vs single-binary distribution
- IPC overhead for performance-critical UIs
- Partial Fyne coverage (~15%)
- Fyne's styling limitations