### PR TITLE
Implement Activity feature with demo app

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -66,6 +66,8 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreateClip(msg)
 	case "createMax":
 		b.handleCreateMax(msg)
+	case "createStack":
+		b.handleCreateStack(msg)
 	case "createCard":
 		b.handleCreateCard(msg)
 	case "createAccordion":

--- a/examples/card-stack.test.ts
+++ b/examples/card-stack.test.ts
@@ -1,0 +1,139 @@
+// Test for Card Stack example - demonstrates Stack container for Z-layered UI
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+describe('Card Stack Example', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display stacked cards with controls', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Card Stack Demo', width: 600, height: 500 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Card Stack Demo');
+            app.label('Click the buttons below to bring cards to the front');
+
+            // Card control buttons
+            app.hbox(() => {
+              app.button('Show Card 1', () => {});
+              app.button('Show Card 2', () => {});
+              app.button('Show Card 3', () => {});
+            });
+
+            // Stack container - cards are layered on top of each other
+            app.stack(() => {
+              // Card 1 (bottom)
+              app.card('Card 1', 'First card in the stack', () => {
+                app.vbox(() => {
+                  app.label('This is Card 1');
+                  app.label('It appears at the bottom of the stack');
+                });
+              });
+
+              // Card 2 (middle)
+              app.card('Card 2', 'Second card in the stack', () => {
+                app.vbox(() => {
+                  app.label('This is Card 2');
+                  app.label('It appears in the middle of the stack');
+                });
+              });
+
+              // Card 3 (top)
+              app.card('Card 3', 'Third card in the stack', () => {
+                app.vbox(() => {
+                  app.label('This is Card 3');
+                  app.label('It appears on top of the stack');
+                });
+              });
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify the stack container and its cards are visible
+    await ctx.expect(ctx.getByExactText('Card Stack Demo')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Card 1')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Card 2')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Card 3')).toBeVisible();
+
+    // Verify control buttons are present
+    await ctx.expect(ctx.getByExactText('Show Card 1')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Show Card 2')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Show Card 3')).toBeVisible();
+
+    // Capture screenshot if TAKE_SCREENSHOTS=1
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'card-stack.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+  });
+
+  test('should create stack with multiple children', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Stack Test', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.stack(() => {
+            app.label('Layer 1 - Bottom');
+            app.label('Layer 2 - Middle');
+            app.label('Layer 3 - Top');
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // All layers should exist in the stack
+    await ctx.expect(ctx.getByExactText('Layer 1 - Bottom')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Layer 2 - Middle')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Layer 3 - Top')).toBeVisible();
+  });
+
+  test('should support nested containers in stack', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Nested Stack Test', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.stack(() => {
+            // Background layer
+            app.vbox(() => {
+              app.label('Background');
+            });
+            // Foreground layer
+            app.vbox(() => {
+              app.label('Foreground');
+              app.button('Action', () => {});
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Both layers should be visible
+    await ctx.expect(ctx.getByExactText('Background')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Foreground')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Action')).toBeVisible();
+  });
+});

--- a/examples/card-stack.ts
+++ b/examples/card-stack.ts
@@ -1,0 +1,96 @@
+// Portions copyright Ryelang developers (Apache 2.0)
+// Card Stack Demo - demonstrates the Stack container for Z-layered overlapping UI
+// Stack container places widgets on top of each other like a deck of cards
+
+import { app } from '../src';
+
+app({ title: 'Card Stack Demo' }, (a) => {
+  a.window({ title: 'Card Stack Demo', width: 600, height: 500 }, (win) => {
+    // State to track which card is on top
+    let topCardIndex = 2;
+    const cardLabels: any[] = [];
+
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Card Stack Demo', undefined, 'center', undefined, { bold: true });
+        a.label('Click the buttons below to bring cards to the front', undefined, 'center');
+        a.separator();
+
+        // Card control buttons
+        a.hbox(() => {
+          a.button('Show Card 1', () => {
+            topCardIndex = 0;
+            updateCardHighlights();
+          });
+          a.button('Show Card 2', () => {
+            topCardIndex = 1;
+            updateCardHighlights();
+          });
+          a.button('Show Card 3', () => {
+            topCardIndex = 2;
+            updateCardHighlights();
+          });
+        });
+
+        a.separator();
+
+        // Stack container - cards are layered on top of each other
+        // The last card in the builder appears on top (z-order)
+        a.stack(() => {
+          // Card 1 (bottom) - Red themed
+          a.card('Card 1', 'First card in the stack', () => {
+            a.vbox(() => {
+              const lbl = a.label('This is Card 1');
+              cardLabels[0] = lbl;
+              a.label('It appears at the bottom of the stack');
+              a.label('Cards are layered with later items on top');
+            });
+          });
+
+          // Card 2 (middle) - Green themed
+          a.card('Card 2', 'Second card in the stack', () => {
+            a.vbox(() => {
+              const lbl = a.label('This is Card 2');
+              cardLabels[1] = lbl;
+              a.label('It appears in the middle of the stack');
+              a.label('Stack is useful for overlays and floating UI');
+            });
+          });
+
+          // Card 3 (top) - Blue themed
+          a.card('Card 3', 'Third card in the stack', () => {
+            a.vbox(() => {
+              const lbl = a.label('This is Card 3');
+              cardLabels[2] = lbl;
+              a.label('It appears on top of the stack');
+              a.label('The last item in the builder is the topmost');
+            });
+          });
+        });
+
+        a.separator();
+
+        // Status indicator
+        const statusLabel = a.label('Currently viewing: Card 3 (top of stack)');
+
+        // Update function to show which card is "active"
+        function updateCardHighlights() {
+          const cardNames = ['Card 1', 'Card 2', 'Card 3'];
+          statusLabel.setText(`Currently viewing: ${cardNames[topCardIndex]}`);
+
+          // Update card labels to indicate selection
+          for (let i = 0; i < 3; i++) {
+            if (cardLabels[i]) {
+              if (i === topCardIndex) {
+                cardLabels[i].setText(`This is ${cardNames[i]} (SELECTED)`);
+              } else {
+                cardLabels[i].setText(`This is ${cardNames[i]}`);
+              }
+            }
+          }
+        }
+      });
+    });
+    win.show();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -211,6 +211,10 @@ export class App {
 
   max(builder: () => void): Max {
     return new Max(this.ctx, builder);
+  }
+
+  stack(builder: () => void): Stack {
+    return new Stack(this.ctx, builder);
   }
 
   card(title: string, subtitle: string, builder: () => void): Card {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App, AppOptions } from './app';
 import { Context } from './context';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
 import { Window, WindowOptions, ProgressDialog } from './window';
 
 // Global context for the declarative API
@@ -310,6 +310,16 @@ export function center(builder: () => void): Center {
 }
 
 /**
+ * Create a stack layout (Z-layering, overlapping children)
+ */
+export function stack(builder: () => void): Stack {
+  if (!globalContext) {
+    throw new Error('stack() must be called within an app context');
+  }
+  return new Stack(globalContext, builder);
+}
+
+/**
  * Create a card container with title, subtitle, and content
  */
 export function card(title: string, subtitle: string, builder: () => void): Card {
@@ -523,7 +533,7 @@ export async function setFontScale(scale: number): Promise<void> {
 }
 
 // Export classes for advanced usage
-export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow };
+export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow };
 export type { AppOptions, WindowOptions, MenuItem };
 
 // Export theming types

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -1662,6 +1662,63 @@ export class Max {
 }
 
 /**
+ * Stack layout - stacks widgets on top of each other (Z-layering)
+ * All widgets are positioned at the same location, creating overlapping layers.
+ * Unlike Max, Stack preserves natural sizes - children are not forced to fill the container.
+ * Useful for layered UIs like card stacks, overlays, or floating elements.
+ */
+export class Stack {
+  private ctx: Context;
+  public id: string;
+
+  constructor(ctx: Context, builder: () => void) {
+    this.ctx = ctx;
+    this.id = ctx.generateId('stack');
+
+    // Build child content
+    ctx.pushContainer();
+    builder();
+    const children = ctx.popContainer();
+
+    if (children.length === 0) {
+      throw new Error('Stack must have at least one child');
+    }
+
+    ctx.bridge.send('createStack', {
+      id: this.id,
+      childIds: children
+    });
+
+    ctx.addToCurrentContainer(this.id);
+  }
+
+  /**
+   * Register a custom ID for this widget (for testing/debugging)
+   * @param customId Custom ID to register
+   * @returns this for method chaining
+   */
+  withId(customId: string): this {
+    this.ctx.bridge.send('registerCustomId', {
+      widgetId: this.id,
+      customId
+    });
+    return this;
+  }
+
+  async hide(): Promise<void> {
+    await this.ctx.bridge.send('hideWidget', {
+      widgetId: this.id
+    });
+  }
+
+  async show(): Promise<void> {
+    await this.ctx.bridge.send('showWidget', {
+      widgetId: this.id
+    });
+  }
+}
+
+/**
  * Card container with title, subtitle, and content
  */
 export class Card {


### PR DESCRIPTION
Implements the Stack container from ROADMAP.md which allows layering widgets on top of each other (Z-axis stacking). Unlike Max, Stack preserves natural widget sizes rather than forcing all children to fill.

Changes:
- Add handleCreateStack handler in Go bridge (widget_creators.go)
- Add Stack class in TypeScript (widgets.ts)
- Export stack() function in index.ts and add stack() method to App
- Add card-stack.ts demo showing overlapping card UI
- Add card-stack.test.ts with 3 passing tests