### PR TITLE
Implement widget.Select with demo app

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -52,6 +52,10 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreateCheckbox(msg)
 	case "createSelect":
 		b.handleCreateSelect(msg)
+	case "createSelectEntry":
+		b.handleCreateSelectEntry(msg)
+	case "setSelectEntryOptions":
+		b.handleSetSelectEntryOptions(msg)
 	case "createSlider":
 		b.handleCreateSlider(msg)
 	case "createProgressBar":

--- a/bridge/widget_properties.go
+++ b/bridge/widget_properties.go
@@ -46,6 +46,8 @@ func (b *Bridge) handleGetText(msg Message) {
 		text = w.Text
 	case *widget.Entry:
 		text = w.Text
+	case *widget.SelectEntry:
+		text = w.Text
 	case *widget.Button:
 		text = w.Text
 	case *HoverableButton: // Handle HoverableButton
@@ -108,6 +110,8 @@ func (b *Bridge) handleSetText(msg Message) {
 			w.SetText(text)
 		case *widget.Entry:
 			w.SetText(text)
+		case *widget.SelectEntry:
+			w.SetText(text)
 		case *widget.Button:
 			w.SetText(text)
 		case *HoverableButton:
@@ -130,7 +134,7 @@ func (b *Bridge) handleSetText(msg Message) {
 	// Check if widget type is supported
 	supported := false
 	switch actualWidget.(type) {
-	case *widget.Label, *widget.Entry, *widget.Button, *HoverableButton, *HoverableWrapper, *widget.Check:
+	case *widget.Label, *widget.Entry, *widget.SelectEntry, *widget.Button, *HoverableButton, *HoverableWrapper, *widget.Check:
 		supported = true
 	}
 
@@ -1491,4 +1495,45 @@ func (b *Bridge) handleSetWidgetHoverable(msg Message) {
 		ID:      msg.ID,
 		Success: true,
 	})
+}
+
+func (b *Bridge) handleSetSelectEntryOptions(msg Message) {
+	widgetID := msg.Payload["widgetId"].(string)
+	optionsInterface, _ := msg.Payload["options"].([]interface{})
+
+	// Convert []interface{} to []string
+	options := make([]string, len(optionsInterface))
+	for i, opt := range optionsInterface {
+		options[i] = opt.(string)
+	}
+
+	b.mu.RLock()
+	obj, exists := b.widgets[widgetID]
+	b.mu.RUnlock()
+
+	if !exists {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget not found",
+		})
+		return
+	}
+
+	if selectEntry, ok := obj.(*widget.SelectEntry); ok {
+		// UI updates must happen on the main thread
+		fyne.DoAndWait(func() {
+			selectEntry.SetOptions(options)
+		})
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: true,
+		})
+	} else {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget is not a SelectEntry",
+		})
+	}
 }

--- a/examples/country-picker.test.ts
+++ b/examples/country-picker.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Test for SelectEntry (Country Picker) widget
+ */
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+// Sample list of countries for testing
+const countries = [
+  'Afghanistan', 'Australia', 'Austria',
+  'Belgium', 'Brazil',
+  'Canada', 'China',
+  'Denmark',
+  'France',
+  'Germany',
+  'India', 'Italy',
+  'Japan',
+  'Mexico',
+  'Netherlands', 'New Zealand',
+  'Poland', 'Portugal',
+  'Spain', 'Sweden', 'Switzerland',
+  'United Kingdom', 'United States'
+];
+
+describe('Country Picker (SelectEntry) Example', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display SelectEntry and allow typing', async () => {
+    let selectedCountry = '';
+    let submittedText = '';
+    let statusLabel: any;
+    let selectEntryWidget: any;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Country Picker Test', width: 500, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Select your country:');
+
+            selectEntryWidget = app.selectentry(
+              countries,
+              'Type to search countries...',
+              (text) => {
+                // onChanged
+                console.log(`Changed: ${text}`);
+              },
+              (text) => {
+                // onSubmitted
+                submittedText = text;
+                statusLabel.setText(`Submitted: ${text}`);
+              },
+              (selected) => {
+                // onSelected
+                selectedCountry = selected;
+                statusLabel.setText(`Selected: ${selected}`);
+              }
+            );
+
+            app.separator();
+
+            statusLabel = app.label('No country selected yet');
+
+            app.button('Show Selection', () => {
+              console.log(`Current selection: ${selectedCountry || submittedText || 'none'}`);
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify initial state
+    await ctx.expect(ctx.getByExactText('Select your country:')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('No country selected yet')).toBeVisible();
+
+    // Capture screenshot if TAKE_SCREENSHOTS=1
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'country-picker.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+
+    // Test setText - type a country name
+    await selectEntryWidget.setText('Canada');
+    await ctx.wait(100);
+
+    // Verify the text was set
+    const entryText = await selectEntryWidget.getText();
+    expect(entryText).toBe('Canada');
+  });
+
+  test('should allow programmatic text updates', async () => {
+    let selectEntryWidget: any;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'SelectEntry Test', width: 400, height: 200 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            selectEntryWidget = app.selectentry(
+              countries,
+              'Select a country...'
+            );
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Set text programmatically
+    await selectEntryWidget.setText('Germany');
+    await ctx.wait(100);
+
+    // Verify text was set
+    const text = await selectEntryWidget.getText();
+    expect(text).toBe('Germany');
+
+    // Change to a different country
+    await selectEntryWidget.setText('France');
+    await ctx.wait(100);
+
+    const newText = await selectEntryWidget.getText();
+    expect(newText).toBe('France');
+  });
+
+  test('should allow updating options dynamically', async () => {
+    let selectEntryWidget: any;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Dynamic Options Test', width: 400, height: 200 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            selectEntryWidget = app.selectentry(
+              ['Option 1', 'Option 2', 'Option 3'],
+              'Select an option...'
+            );
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Update options dynamically
+    await selectEntryWidget.setOptions(['New Option A', 'New Option B', 'New Option C']);
+    await ctx.wait(100);
+
+    // We can verify this works by setting text to one of the new options
+    await selectEntryWidget.setText('New Option B');
+    await ctx.wait(100);
+
+    const text = await selectEntryWidget.getText();
+    expect(text).toBe('New Option B');
+  });
+});

--- a/examples/country-picker.ts
+++ b/examples/country-picker.ts
@@ -1,0 +1,96 @@
+/**
+ * Country Picker Demo
+ *
+ * Demonstrates the SelectEntry widget - a searchable dropdown that combines
+ * a text entry with a dropdown menu. Users can type to filter options or
+ * select from the dropdown list.
+ */
+import { app } from '../src';
+
+// Sample list of countries
+const countries = [
+  'Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola',
+  'Argentina', 'Armenia', 'Australia', 'Austria', 'Azerbaijan',
+  'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados', 'Belarus',
+  'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia',
+  'Brazil', 'Brunei', 'Bulgaria', 'Burkina Faso', 'Burundi',
+  'Cambodia', 'Cameroon', 'Canada', 'Chile', 'China',
+  'Colombia', 'Costa Rica', 'Croatia', 'Cuba', 'Cyprus',
+  'Czech Republic', 'Denmark', 'Dominican Republic', 'Ecuador', 'Egypt',
+  'Estonia', 'Ethiopia', 'Finland', 'France', 'Germany',
+  'Ghana', 'Greece', 'Guatemala', 'Haiti', 'Honduras',
+  'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran',
+  'Iraq', 'Ireland', 'Israel', 'Italy', 'Jamaica',
+  'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kuwait',
+  'Latvia', 'Lebanon', 'Libya', 'Lithuania', 'Luxembourg',
+  'Malaysia', 'Mexico', 'Morocco', 'Nepal', 'Netherlands',
+  'New Zealand', 'Nigeria', 'Norway', 'Pakistan', 'Panama',
+  'Peru', 'Philippines', 'Poland', 'Portugal', 'Qatar',
+  'Romania', 'Russia', 'Saudi Arabia', 'Singapore', 'Slovakia',
+  'Slovenia', 'South Africa', 'South Korea', 'Spain', 'Sri Lanka',
+  'Sweden', 'Switzerland', 'Taiwan', 'Thailand', 'Turkey',
+  'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay',
+  'Venezuela', 'Vietnam', 'Yemen', 'Zambia', 'Zimbabwe'
+];
+
+// Track selected country
+let selectedCountry = '';
+let statusLabel: any;
+
+app({ title: 'Country Picker' }, (a) => {
+  a.window({ title: 'Country Picker - SelectEntry Demo', width: 500, height: 400 }, (win) => {
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Select your country:');
+
+        // Create the searchable dropdown
+        a.selectentry(
+          countries,
+          'Type to search countries...',
+          (text) => {
+            // onChanged - fires when user types
+            console.log(`Typing: ${text}`);
+          },
+          (text) => {
+            // onSubmitted - fires when user presses Enter
+            selectedCountry = text;
+            console.log(`Submitted: ${text}`);
+            if (statusLabel) {
+              statusLabel.setText(`You submitted: ${text}`);
+            }
+          },
+          (selected) => {
+            // onSelected - fires when user selects from dropdown
+            selectedCountry = selected;
+            console.log(`Selected from dropdown: ${selected}`);
+            if (statusLabel) {
+              statusLabel.setText(`Selected: ${selected}`);
+            }
+          }
+        );
+
+        a.separator();
+
+        // Status label to show selection
+        statusLabel = a.label('No country selected yet');
+
+        a.separator();
+
+        // Button to show current selection
+        a.button('Show Selection', () => {
+          if (selectedCountry) {
+            console.log(`Current selection: ${selectedCountry}`);
+          } else {
+            console.log('No country selected');
+          }
+        });
+
+        // Exit button
+        a.button('Exit', () => {
+          process.exit(0);
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Max, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Padded, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, ThemeOverride, DateEntry, TextGrid, TextGridOptions, TextGridStyle, Navigation, NavigationOptions } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, SelectEntry, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Max, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Padded, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, ThemeOverride, DateEntry, TextGrid, TextGridOptions, TextGridStyle, Navigation, NavigationOptions } from './widgets';
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -155,6 +155,16 @@ export class App {
 
   select(options: string[], onSelected?: (selected: string) => void): Select {
     return new Select(this.ctx, options, onSelected);
+  }
+
+  selectentry(
+    options: string[],
+    placeholder?: string,
+    onChanged?: (text: string) => void,
+    onSubmitted?: (text: string) => void,
+    onSelected?: (selected: string) => void
+  ): SelectEntry {
+    return new SelectEntry(this.ctx, options, placeholder, onChanged, onSubmitted, onSelected);
   }
 
   slider(min: number, max: number, initialValue?: number, onChanged?: (value: number) => void): Slider {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App, AppOptions } from './app';
 import { Context } from './context';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded, ThemeOverride, DateEntry, TextGrid, Navigation, NavigationOptions } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, SelectEntry, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded, ThemeOverride, DateEntry, TextGrid, Navigation, NavigationOptions } from './widgets';
 import { Window, WindowOptions, ProgressDialog } from './window';
 
 // Global context for the declarative API
@@ -152,6 +152,22 @@ export function select(options: string[], onSelected?: (selected: string) => voi
     throw new Error('select() must be called within an app context');
   }
   return new Select(globalContext, options, onSelected);
+}
+
+/**
+ * Create a searchable dropdown (SelectEntry) widget
+ */
+export function selectentry(
+  options: string[],
+  placeholder?: string,
+  onChanged?: (text: string) => void,
+  onSubmitted?: (text: string) => void,
+  onSelected?: (selected: string) => void
+): SelectEntry {
+  if (!globalContext) {
+    throw new Error('selectentry() must be called within an app context');
+  }
+  return new SelectEntry(globalContext, options, placeholder, onChanged, onSubmitted, onSelected);
 }
 
 /**
@@ -618,7 +634,7 @@ export async function setFontScale(scale: number): Promise<void> {
 }
 
 // Export classes for advanced usage
-export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded, ThemeOverride, DateEntry, TextGrid, Navigation };
+export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, SelectEntry, Slider, ProgressBar, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded, ThemeOverride, DateEntry, TextGrid, Navigation };
 export type { AppOptions, WindowOptions, MenuItem, NavigationOptions };
 
 // Export theming types

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -1173,6 +1173,83 @@ export class Select extends Widget {
 }
 
 /**
+ * SelectEntry widget - a searchable dropdown that combines a text entry with a dropdown menu.
+ * Users can type to filter options or select from the dropdown list.
+ */
+export class SelectEntry extends Widget {
+  constructor(
+    ctx: Context,
+    options: string[],
+    placeholder?: string,
+    onChanged?: (text: string) => void,
+    onSubmitted?: (text: string) => void,
+    onSelected?: (selected: string) => void
+  ) {
+    const id = ctx.generateId('selectentry');
+    super(ctx, id);
+
+    const payload: any = { id, options, placeholder: placeholder || '' };
+
+    if (onChanged) {
+      const callbackId = ctx.generateId('callback');
+      payload.onChangedCallbackId = callbackId;
+      ctx.bridge.registerEventHandler(callbackId, (data: any) => {
+        onChanged(data.text);
+      });
+    }
+
+    if (onSubmitted) {
+      const callbackId = ctx.generateId('callback');
+      payload.onSubmittedCallbackId = callbackId;
+      ctx.bridge.registerEventHandler(callbackId, (data: any) => {
+        onSubmitted(data.text);
+      });
+    }
+
+    if (onSelected) {
+      const callbackId = ctx.generateId('callback');
+      payload.onSelectedCallbackId = callbackId;
+      ctx.bridge.registerEventHandler(callbackId, (data: any) => {
+        onSelected(data.selected);
+      });
+    }
+
+    ctx.bridge.send('createSelectEntry', payload);
+    ctx.addToCurrentContainer(id);
+  }
+
+  /**
+   * Set the text value of the entry
+   */
+  async setText(text: string): Promise<void> {
+    await this.ctx.bridge.send('setText', {
+      widgetId: this.id,
+      text
+    });
+  }
+
+  /**
+   * Get the current text value
+   */
+  async getText(): Promise<string> {
+    const result = await this.ctx.bridge.send('getText', {
+      widgetId: this.id
+    });
+    return result.text;
+  }
+
+  /**
+   * Update the dropdown options
+   */
+  async setOptions(options: string[]): Promise<void> {
+    await this.ctx.bridge.send('setSelectEntryOptions', {
+      widgetId: this.id,
+      options
+    });
+  }
+}
+
+/**
  * Slider widget
  */
 export class Slider extends Widget {


### PR DESCRIPTION
Implements widget.SelectEntry from ROADMAP.md - a searchable dropdown that combines a text entry with a dropdown menu. Users can type to filter options or select from the dropdown list.

- Go bridge handler for createSelectEntry and setSelectEntryOptions
- TypeScript SelectEntry class with setText, getText, setOptions methods
- Export and declarative API function in index.ts and app.ts
- Demo app: country-picker.ts with 100+ countries
- Tests: 3 passing tests for text input and dynamic options