### PR TITLE
Implement container.Pa with demo app

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -90,6 +90,8 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreateBorder(msg)
 	case "createGridWrap":
 		b.handleCreateGridWrap(msg)
+	case "createPadded":
+		b.handleCreatePadded(msg)
 	case "createRadioGroup":
 		b.handleCreateRadioGroup(msg)
 	case "createSplit":

--- a/examples/padded-demo.test.ts
+++ b/examples/padded-demo.test.ts
@@ -1,0 +1,125 @@
+// Test for padded container demo
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+describe('Padded Container Demo', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display padded and non-padded content comparison', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Padded Container Demo', width: 500, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            // Title
+            app.label('Padded Container Demo', undefined, 'center', undefined, { bold: true });
+            app.separator();
+
+            // Side-by-side comparison using split
+            app.hsplit(
+              // Left side: Without padding
+              () => {
+                app.vbox(() => {
+                  app.label('Without Padding:', undefined, undefined, undefined, { bold: true });
+                  app.card('Card Title', 'No padding around content', () => {
+                    app.vbox(() => {
+                      app.label('This content has no extra padding');
+                      app.button('Button 1', () => {});
+                      app.button('Button 2', () => {});
+                    });
+                  });
+                });
+              },
+              // Right side: With padding
+              () => {
+                app.vbox(() => {
+                  app.label('With Padding:', undefined, undefined, undefined, { bold: true });
+                  app.card('Card Title', 'Theme padding around content', () => {
+                    app.padded(() => {
+                      app.vbox(() => {
+                        app.label('This content has theme padding');
+                        app.button('Button 1', () => {});
+                        app.button('Button 2', () => {});
+                      });
+                    });
+                  });
+                });
+              },
+              0.5
+            );
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify the title is visible
+    await ctx.expect(ctx.getByExactText('Padded Container Demo')).toBeVisible();
+
+    // Verify both comparison labels are visible
+    await ctx.expect(ctx.getByExactText('Without Padding:')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('With Padding:')).toBeVisible();
+
+    // Verify content in both sections
+    await ctx.expect(ctx.getByExactText('This content has no extra padding')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('This content has theme padding')).toBeVisible();
+
+    // Capture screenshot if TAKE_SCREENSHOTS=1
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'padded-demo.png');
+      await ctx.wait(500); // Wait for rendering
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+  });
+
+  test('should allow padded container with single child', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Padded Test', width: 300, height: 200 }, (win) => {
+        win.setContent(() => {
+          app.padded(() => {
+            app.label('Padded Label');
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    await ctx.expect(ctx.getByExactText('Padded Label')).toBeVisible();
+  });
+
+  test('should allow nested padded containers', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Nested Padded', width: 300, height: 200 }, (win) => {
+        win.setContent(() => {
+          app.padded(() => {
+            app.padded(() => {
+              app.label('Double Padded');
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    await ctx.expect(ctx.getByExactText('Double Padded')).toBeVisible();
+  });
+});

--- a/examples/padded-demo.ts
+++ b/examples/padded-demo.ts
@@ -1,0 +1,69 @@
+// Padded container demo - demonstrates container.NewPadded functionality
+// Shows the difference between padded and non-padded content
+
+import { app } from '../src';
+
+app({ title: 'Padded Demo' }, (a) => {
+  a.window({ title: 'Padded Container Demo', width: 500, height: 400 }, (win) => {
+    win.setContent(() => {
+      a.vbox(() => {
+        // Title
+        a.label('Padded Container Demo', undefined, 'center', undefined, { bold: true });
+        a.separator();
+
+        // Side-by-side comparison using split
+        a.hsplit(
+          // Left side: Without padding
+          () => {
+            a.vbox(() => {
+              a.label('Without Padding:', undefined, undefined, undefined, { bold: true });
+              a.card('Card Title', 'No padding around content', () => {
+                a.vbox(() => {
+                  a.label('This content has no extra padding');
+                  a.button('Button 1', () => console.log('Button 1 clicked'));
+                  a.button('Button 2', () => console.log('Button 2 clicked'));
+                });
+              });
+            });
+          },
+          // Right side: With padding
+          () => {
+            a.vbox(() => {
+              a.label('With Padding:', undefined, undefined, undefined, { bold: true });
+              a.card('Card Title', 'Theme padding around content', () => {
+                a.padded(() => {
+                  a.vbox(() => {
+                    a.label('This content has theme padding');
+                    a.button('Button 1', () => console.log('Padded Button 1 clicked'));
+                    a.button('Button 2', () => console.log('Padded Button 2 clicked'));
+                  });
+                });
+              });
+            });
+          },
+          0.5
+        );
+
+        a.separator();
+
+        // More examples
+        a.label('More Padded Examples:', undefined, undefined, undefined, { bold: true });
+
+        // Padded label
+        a.padded(() => {
+          a.label('This label is wrapped in a padded container');
+        });
+
+        // Padded button row
+        a.padded(() => {
+          a.hbox(() => {
+            a.button('Padded', () => console.log('Padded button'));
+            a.button('Button', () => console.log('Button'));
+            a.button('Row', () => console.log('Row'));
+          });
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Padded, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -290,6 +290,10 @@ export class App {
 
   innerWindow(title: string, builder: () => void, onClose?: () => void): InnerWindow {
     return new InnerWindow(this.ctx, title, builder, onClose);
+  }
+
+  padded(builder: () => void): Padded {
+    return new Padded(this.ctx, builder);
   }
 
   async run(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App, AppOptions } from './app';
 import { Context } from './context';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded } from './widgets';
 import { Window, WindowOptions, ProgressDialog } from './window';
 
 // Global context for the declarative API
@@ -446,6 +446,16 @@ export function innerWindow(title: string, builder: () => void, onClose?: () => 
 }
 
 /**
+ * Create a padded container (adds theme padding around content)
+ */
+export function padded(builder: () => void): Padded {
+  if (!globalContext) {
+    throw new Error('padded() must be called within an app context');
+  }
+  return new Padded(globalContext, builder);
+}
+
+/**
  * Set the application theme
  */
 export async function setTheme(theme: 'dark' | 'light'): Promise<void> {
@@ -533,7 +543,7 @@ export async function setFontScale(scale: number): Promise<void> {
 }
 
 // Export classes for advanced usage
-export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow };
+export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Stack, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, Padded };
 export type { AppOptions, WindowOptions, MenuItem };
 
 // Export theming types

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -2573,3 +2573,33 @@ export class InnerWindow {
     return this;
   }
 }
+
+/**
+ * Padded container - adds theme-appropriate padding around content
+ * Uses Fyne's container.NewPadded which adds standard theme padding
+ */
+export class Padded {
+  private ctx: Context;
+  public id: string;
+
+  constructor(ctx: Context, builder: () => void) {
+    this.ctx = ctx;
+    this.id = ctx.generateId('padded');
+
+    // Build child content
+    ctx.pushContainer();
+    builder();
+    const children = ctx.popContainer();
+
+    if (children.length !== 1) {
+      throw new Error('Padded must have exactly one child');
+    }
+
+    ctx.bridge.send('createPadded', {
+      id: this.id,
+      childId: children[0]
+    });
+
+    ctx.addToCurrentContainer(this.id);
+  }
+}


### PR DESCRIPTION
Implement Fyne's container.NewPadded which adds theme-appropriate padding around content. Includes:
- Go bridge handler (handleCreatePadded)
- TypeScript Padded class in widgets.ts
- Factory method padded() in App class
- Exports in index.ts
- Demo app (padded-demo.ts) comparing padded vs non-padded content
- Tests validating basic, nested, and complex padded layouts