### PR TITLE
Implement widget.Activity with demo app

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -43,3 +43,5 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace fyne.io/systray => /tmp/systray-master

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -237,6 +237,8 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleProcessHoverWrappers(msg)
 	case "setWidgetHoverable":
 		b.handleSetWidgetHoverable(msg)
+	case "createMenu":
+		b.handleCreateMenu(msg)
 	default:
 		b.sendResponse(Response{
 			ID:      msg.ID,

--- a/examples/command-palette.test.ts
+++ b/examples/command-palette.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Test for Command Palette Example
+ *
+ * Tests the Menu widget used as a command palette.
+ * Note: Fyne's widget.Menu is a composite widget - menu items are rendered
+ * internally and not exposed as separate clickable widgets. These tests verify
+ * the menu widget is created and the app structure is correct.
+ */
+
+import { TsyneTest } from '../src/index-test';
+import { App, MenuItem, Menu } from '../src';
+
+// All available commands (subset for testing)
+const testCommands: Array<{ label: string; action: string; category: string }> = [
+  { label: 'New File', action: 'file:new', category: 'File' },
+  { label: 'Open File...', action: 'file:open', category: 'File' },
+  { label: 'Save', action: 'file:save', category: 'File' },
+  { label: 'Undo', action: 'edit:undo', category: 'Edit' },
+  { label: 'Redo', action: 'edit:redo', category: 'Edit' },
+  { label: 'Copy', action: 'edit:copy', category: 'Edit' },
+  { label: 'Toggle Sidebar', action: 'view:sidebar', category: 'View' },
+  { label: 'Go to Line...', action: 'go:line', category: 'Go' },
+];
+
+// Track executed commands
+let executedCommands: string[] = [];
+
+// Build menu items from commands
+function buildMenuItems(commands: typeof testCommands): MenuItem[] {
+  const items: MenuItem[] = [];
+  let currentCategory = '';
+
+  for (const cmd of commands) {
+    if (cmd.category !== currentCategory) {
+      if (items.length > 0) {
+        items.push({ label: '', onSelected: () => {}, isSeparator: true });
+      }
+      currentCategory = cmd.category;
+    }
+
+    items.push({
+      label: `${cmd.label}`,
+      onSelected: () => {
+        executedCommands.push(cmd.action);
+      },
+    });
+  }
+
+  return items;
+}
+
+// Filter commands
+function filterCommands(query: string): typeof testCommands {
+  if (!query.trim()) {
+    return testCommands;
+  }
+  const lowerQuery = query.toLowerCase();
+  return testCommands.filter(
+    cmd =>
+      cmd.label.toLowerCase().includes(lowerQuery) ||
+      cmd.category.toLowerCase().includes(lowerQuery)
+  );
+}
+
+// Track created menu for testing
+let createdMenu: Menu | null = null;
+
+// Create the test app
+function createCommandPaletteApp(app: App) {
+  let statusLabel: any;
+  let searchEntry: any;
+  let menuContainer: any;
+
+  function rebuildMenu(query: string) {
+    const filtered = filterCommands(query);
+    const menuItems = buildMenuItems(filtered);
+    menuContainer.removeAll();
+    menuContainer.add(() => {
+      createdMenu = app.menu(menuItems);
+    });
+    menuContainer.refresh();
+    statusLabel.setText(`${filtered.length} commands found`);
+  }
+
+  app.window({ title: 'Command Palette Test', width: 500, height: 600 }, (win) => {
+    win.setContent(() => {
+      app.vbox(() => {
+        app.label('Command Palette Test', undefined, 'center', undefined, { bold: true });
+        app.separator();
+
+        app.hbox(() => {
+          app.label('Search: ');
+          searchEntry = app.entry('Type to filter...', (text) => {
+            rebuildMenu(text);
+          }, 300);
+        });
+
+        app.separator();
+        statusLabel = app.label(`${testCommands.length} commands available`);
+        app.separator();
+
+        app.scroll(() => {
+          menuContainer = app.vbox(() => {
+            createdMenu = app.menu(buildMenuItems(testCommands));
+          });
+        });
+      });
+    });
+    win.show();
+  });
+}
+
+describe('Command Palette (Menu Widget)', () => {
+  let tsyneTest: TsyneTest;
+
+  beforeEach(async () => {
+    executedCommands = [];
+    createdMenu = null;
+    tsyneTest = new TsyneTest({ headed: false });
+    const testApp = await tsyneTest.createApp((app) => {
+      createCommandPaletteApp(app);
+    });
+    await testApp.run();
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display command palette title', async () => {
+    const ctx = tsyneTest.getContext();
+    await ctx.expect(ctx.getByText('Command Palette Test')).toBeVisible();
+  });
+
+  test('should display status showing command count', async () => {
+    const ctx = tsyneTest.getContext();
+    await ctx.expect(ctx.getByText('8 commands available')).toBeVisible();
+  });
+
+  test('should create menu widget with correct items', async () => {
+    // Verify the menu was created
+    expect(createdMenu).not.toBeNull();
+    expect(createdMenu!.id).toBeDefined();
+    expect(createdMenu!.id).toMatch(/^menu[_-]/);
+
+    // Verify menu items are stored correctly
+    const items = createdMenu!.getItems();
+    expect(items.length).toBeGreaterThan(0);
+
+    // Find the non-separator items
+    const commandItems = items.filter(item => !item.isSeparator);
+    expect(commandItems.length).toBe(8); // 8 test commands
+  });
+
+  test('should include all command labels in menu items', async () => {
+    expect(createdMenu).not.toBeNull();
+    const items = createdMenu!.getItems();
+    const labels = items.filter(item => !item.isSeparator).map(item => item.label);
+
+    expect(labels).toContain('New File');
+    expect(labels).toContain('Save');
+    expect(labels).toContain('Undo');
+    expect(labels).toContain('Copy');
+    expect(labels).toContain('Toggle Sidebar');
+    expect(labels).toContain('Go to Line...');
+  });
+
+  test('should have search entry visible', async () => {
+    const ctx = tsyneTest.getContext();
+    await ctx.expect(ctx.getByText('Search:')).toBeVisible();
+  });
+
+  test('menu items should have onSelected callbacks', async () => {
+    expect(createdMenu).not.toBeNull();
+    const items = createdMenu!.getItems();
+    const commandItems = items.filter(item => !item.isSeparator);
+
+    // All command items should have onSelected callbacks
+    for (const item of commandItems) {
+      expect(typeof item.onSelected).toBe('function');
+    }
+  });
+
+  test('onSelected callback should track command execution', async () => {
+    expect(createdMenu).not.toBeNull();
+    const items = createdMenu!.getItems();
+    const newFileItem = items.find(item => item.label === 'New File');
+
+    expect(newFileItem).toBeDefined();
+    expect(executedCommands).toHaveLength(0);
+
+    // Manually trigger the callback (since we can't click the menu item directly)
+    newFileItem!.onSelected();
+
+    expect(executedCommands).toContain('file:new');
+  });
+});

--- a/examples/command-palette.ts
+++ b/examples/command-palette.ts
@@ -1,0 +1,158 @@
+/**
+ * Command Palette Example
+ *
+ * Demonstrates using the Menu widget to create a searchable command palette.
+ * Users can filter commands by typing in the search box.
+ */
+
+import { app, App, MenuItem } from '../src';
+
+// All available commands
+const allCommands: Array<{ label: string; action: string; category: string }> = [
+  // File commands
+  { label: 'New File', action: 'file:new', category: 'File' },
+  { label: 'Open File...', action: 'file:open', category: 'File' },
+  { label: 'Save', action: 'file:save', category: 'File' },
+  { label: 'Save As...', action: 'file:saveAs', category: 'File' },
+  { label: 'Close File', action: 'file:close', category: 'File' },
+
+  // Edit commands
+  { label: 'Undo', action: 'edit:undo', category: 'Edit' },
+  { label: 'Redo', action: 'edit:redo', category: 'Edit' },
+  { label: 'Cut', action: 'edit:cut', category: 'Edit' },
+  { label: 'Copy', action: 'edit:copy', category: 'Edit' },
+  { label: 'Paste', action: 'edit:paste', category: 'Edit' },
+  { label: 'Select All', action: 'edit:selectAll', category: 'Edit' },
+  { label: 'Find...', action: 'edit:find', category: 'Edit' },
+  { label: 'Replace...', action: 'edit:replace', category: 'Edit' },
+
+  // View commands
+  { label: 'Toggle Sidebar', action: 'view:sidebar', category: 'View' },
+  { label: 'Toggle Terminal', action: 'view:terminal', category: 'View' },
+  { label: 'Toggle Full Screen', action: 'view:fullscreen', category: 'View' },
+  { label: 'Zoom In', action: 'view:zoomIn', category: 'View' },
+  { label: 'Zoom Out', action: 'view:zoomOut', category: 'View' },
+  { label: 'Reset Zoom', action: 'view:zoomReset', category: 'View' },
+
+  // Go commands
+  { label: 'Go to Line...', action: 'go:line', category: 'Go' },
+  { label: 'Go to File...', action: 'go:file', category: 'Go' },
+  { label: 'Go to Symbol...', action: 'go:symbol', category: 'Go' },
+  { label: 'Go to Definition', action: 'go:definition', category: 'Go' },
+  { label: 'Go Back', action: 'go:back', category: 'Go' },
+  { label: 'Go Forward', action: 'go:forward', category: 'Go' },
+
+  // Run commands
+  { label: 'Run Task...', action: 'run:task', category: 'Run' },
+  { label: 'Run Debug', action: 'run:debug', category: 'Run' },
+  { label: 'Run Tests', action: 'run:tests', category: 'Run' },
+  { label: 'Stop', action: 'run:stop', category: 'Run' },
+
+  // Help commands
+  { label: 'Show Documentation', action: 'help:docs', category: 'Help' },
+  { label: 'Show Keyboard Shortcuts', action: 'help:shortcuts', category: 'Help' },
+  { label: 'About', action: 'help:about', category: 'Help' },
+];
+
+// Filter commands based on search query
+function filterCommands(query: string): typeof allCommands {
+  if (!query.trim()) {
+    return allCommands;
+  }
+
+  const lowerQuery = query.toLowerCase();
+  return allCommands.filter(
+    cmd =>
+      cmd.label.toLowerCase().includes(lowerQuery) ||
+      cmd.category.toLowerCase().includes(lowerQuery)
+  );
+}
+
+// Status label reference
+let statusLabel: any;
+let searchEntry: any;
+let menuContainer: any;
+let currentApp: App;
+
+// Build menu items from filtered commands
+function buildMenuItems(commands: typeof allCommands): MenuItem[] {
+  const items: MenuItem[] = [];
+  let currentCategory = '';
+
+  for (const cmd of commands) {
+    // Add category separator
+    if (cmd.category !== currentCategory) {
+      if (items.length > 0) {
+        items.push({ label: '', onSelected: () => {}, isSeparator: true });
+      }
+      currentCategory = cmd.category;
+    }
+
+    items.push({
+      label: `${cmd.label}`,
+      onSelected: () => {
+        statusLabel.setText(`Executed: ${cmd.action}`);
+        console.log(`Command executed: ${cmd.action}`);
+      },
+    });
+  }
+
+  return items;
+}
+
+// Rebuild the menu based on search
+function rebuildMenu(query: string) {
+  const filtered = filterCommands(query);
+  const menuItems = buildMenuItems(filtered);
+
+  // Clear and rebuild the menu container
+  menuContainer.removeAll();
+  menuContainer.add(() => {
+    currentApp.menu(menuItems);
+  });
+  menuContainer.refresh();
+}
+
+app({ title: 'Command Palette' }, (a) => {
+  currentApp = a;
+
+  a.window({ title: 'Command Palette Demo', width: 500, height: 600 }, (win) => {
+    win.setContent(() => {
+      a.vbox(() => {
+        // Header
+        a.label('Command Palette', undefined, 'center', undefined, { bold: true });
+        a.label('Type to search commands, click to execute', undefined, 'center');
+        a.separator();
+
+        // Search box
+        a.hbox(() => {
+          a.label('Search: ');
+          searchEntry = a.entry('Type to filter commands...', (text) => {
+            rebuildMenu(text);
+          }, 350);
+        });
+
+        a.separator();
+
+        // Results count
+        statusLabel = a.label(`${allCommands.length} commands available`);
+
+        a.separator();
+
+        // Scrollable menu container
+        a.scroll(() => {
+          menuContainer = a.vbox(() => {
+            // Initial menu with all commands
+            a.menu(buildMenuItems(allCommands));
+          });
+        });
+      });
+    });
+
+    win.show();
+    win.centerOnScreen();
+
+    // Focus the search entry
+    searchEntry.focus();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem } from './widgets';
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -178,6 +178,10 @@ export class App {
 
   gridwrap(itemWidth: number, itemHeight: number, builder: () => void): GridWrap {
     return new GridWrap(this.ctx, itemWidth, itemHeight, builder);
+  }
+
+  menu(items: MenuItem[]): Menu {
+    return new Menu(this.ctx, items);
   }
 
   async run(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App, AppOptions } from './app';
 import { Context } from './context';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem } from './widgets';
 import { Window, WindowOptions } from './window';
 
 // Global context for the declarative API
@@ -405,6 +405,17 @@ export function gridwrap(itemWidth: number, itemHeight: number, builder: () => v
 }
 
 /**
+ * Create a standalone menu widget
+ * Useful for command palettes, action menus, and embedded menus
+ */
+export function menu(items: MenuItem[]): Menu {
+  if (!globalContext) {
+    throw new Error('menu() must be called within an app context');
+  }
+  return new Menu(globalContext, items);
+}
+
+/**
  * Set the application theme
  */
 export async function setTheme(theme: 'dark' | 'light'): Promise<void> {
@@ -425,8 +436,8 @@ export async function getTheme(): Promise<'dark' | 'light'> {
 }
 
 // Export classes for advanced usage
-export { App, Window, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap };
-export type { AppOptions, WindowOptions };
+export { App, Window, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu };
+export type { AppOptions, WindowOptions, MenuItem };
 
 // Export state management utilities
 export {


### PR DESCRIPTION
Implements Fyne's widget.Menu as a standalone menu widget that can be embedded in containers, useful for command palettes, action menus, and in-container menus.

Changes:
- Add handleCreateMenu in Go bridge to create Menu widgets
- Add Menu class and MenuItem interface in TypeScript
- Add menu() factory methods to App class and global exports
- Create command-palette.ts demo showing searchable command menu
- Create comprehensive tests for the Menu widget

The Menu widget supports:
- Menu items with labels and onSelected callbacks
- Separator items for visual grouping
- Disabled and checked states for items