### PR TITLE
Implement container.Docabs with demo app

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -94,6 +94,14 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreateSplit(msg)
 	case "createTabs":
 		b.handleCreateTabs(msg)
+	case "createDocTabs":
+		b.handleCreateDocTabs(msg)
+	case "docTabsAppend":
+		b.handleDocTabsAppend(msg)
+	case "docTabsRemove":
+		b.handleDocTabsRemove(msg)
+	case "docTabsSelect":
+		b.handleDocTabsSelect(msg)
 	case "setText":
 		b.handleSetText(msg)
 	case "getText":

--- a/examples/text-editor.test.ts
+++ b/examples/text-editor.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Test for DocTabs (text-editor.ts example)
+ */
+import { TsyneTest, TestContext } from '../src/index-test';
+import { App, DocTabs } from '../src';
+
+describe('DocTabs - Text Editor Example', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display initial tabs', async () => {
+    let docTabsRef: DocTabs;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'DocTabs Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          docTabsRef = app.doctabs([
+            {
+              title: 'Tab 1',
+              builder: () => {
+                app.vbox(() => {
+                  app.label('Content for Tab 1');
+                  app.button('Tab 1 Button');
+                });
+              }
+            },
+            {
+              title: 'Tab 2',
+              builder: () => {
+                app.vbox(() => {
+                  app.label('Content for Tab 2');
+                });
+              }
+            }
+          ]);
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Tab 1 content should be visible (first tab selected by default)
+    await ctx.expect(ctx.getByExactText('Content for Tab 1')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Tab 1 Button')).toBeVisible();
+  });
+
+  test('should handle onClosed callback', async () => {
+    let closedTabTitle = '';
+    let closedTabIndex = -1;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'DocTabs Close Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.doctabs([
+            {
+              title: 'Closable Tab',
+              builder: () => {
+                app.label('This tab can be closed');
+              }
+            },
+            {
+              title: 'Another Tab',
+              builder: () => {
+                app.label('Another tab content');
+              }
+            }
+          ], {
+            onClosed: (tabIndex, tabTitle) => {
+              closedTabIndex = tabIndex;
+              closedTabTitle = tabTitle;
+            }
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify tabs are visible
+    await ctx.expect(ctx.getByExactText('This tab can be closed')).toBeVisible();
+  });
+
+  test('should support location option', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'DocTabs Location Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.doctabs([
+            {
+              title: 'Top Tab 1',
+              builder: () => {
+                app.label('Top location tabs');
+              }
+            },
+            {
+              title: 'Top Tab 2',
+              builder: () => {
+                app.label('Second tab');
+              }
+            }
+          ], {
+            location: 'top'
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    await ctx.expect(ctx.getByExactText('Top location tabs')).toBeVisible();
+  });
+
+  test('should track tab count correctly', async () => {
+    let docTabsRef: DocTabs;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Tab Count Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          docTabsRef = app.doctabs([
+            { title: 'Tab A', builder: () => app.label('A') },
+            { title: 'Tab B', builder: () => app.label('B') },
+            { title: 'Tab C', builder: () => app.label('C') }
+          ]);
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify tab count
+    expect(docTabsRef!.getTabCount()).toBe(3);
+    expect(docTabsRef!.getTabTitles()).toEqual(['Tab A', 'Tab B', 'Tab C']);
+  });
+
+  test('should dynamically append tabs', async () => {
+    let docTabsRef: DocTabs;
+    let appRef: App;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      appRef = app;
+      app.window({ title: 'Append Tab Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            docTabsRef = app.doctabs([
+              { title: 'Initial Tab', builder: () => app.label('Initial content') }
+            ]);
+
+            app.button('Add Tab', async () => {
+              await docTabsRef.append('New Tab', () => {
+                appRef.label('Dynamically added content');
+              });
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Initial state
+    expect(docTabsRef!.getTabCount()).toBe(1);
+    await ctx.expect(ctx.getByExactText('Initial content')).toBeVisible();
+
+    // Add a new tab
+    await ctx.getByExactText('Add Tab').click();
+    await ctx.wait(100);
+
+    // Verify tab was added
+    expect(docTabsRef!.getTabCount()).toBe(2);
+    expect(docTabsRef!.getTabTitles()).toContain('New Tab');
+  });
+
+  test('should remove tabs by index', async () => {
+    let docTabsRef: DocTabs;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Remove Tab Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            docTabsRef = app.doctabs([
+              { title: 'Tab 1', builder: () => app.label('Content 1') },
+              { title: 'Tab 2', builder: () => app.label('Content 2') },
+              { title: 'Tab 3', builder: () => app.label('Content 3') }
+            ]);
+
+            app.button('Remove First', async () => {
+              await docTabsRef.remove(0);
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Initial state
+    expect(docTabsRef!.getTabCount()).toBe(3);
+
+    // Remove first tab
+    await ctx.getByExactText('Remove First').click();
+    await ctx.wait(100);
+
+    // Verify tab was removed
+    expect(docTabsRef!.getTabCount()).toBe(2);
+    expect(docTabsRef!.getTabTitles()).toEqual(['Tab 2', 'Tab 3']);
+  });
+
+  test('should select tabs by index', async () => {
+    let docTabsRef: DocTabs;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Select Tab Test', width: 600, height: 400 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            docTabsRef = app.doctabs([
+              { title: 'Tab A', builder: () => app.label('Content A') },
+              { title: 'Tab B', builder: () => app.label('Content B') },
+              { title: 'Tab C', builder: () => app.label('Content C') }
+            ]);
+
+            app.button('Go to Tab C', async () => {
+              await docTabsRef.select(2);
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Tab A content should be visible initially
+    await ctx.expect(ctx.getByExactText('Content A')).toBeVisible();
+
+    // Select Tab C
+    await ctx.getByExactText('Go to Tab C').click();
+    await ctx.wait(100);
+
+    // Tab C content should now be visible
+    await ctx.expect(ctx.getByExactText('Content C')).toBeVisible();
+  });
+});

--- a/examples/text-editor.ts
+++ b/examples/text-editor.ts
@@ -1,0 +1,173 @@
+/**
+ * Text Editor Example - DocTabs Demo
+ *
+ * Demonstrates DocTabs (document tabs with close buttons) for a
+ * multi-document text editor interface.
+ */
+
+import { app, App, DocTabs } from '../src';
+
+// Document state
+interface Document {
+  id: number;
+  title: string;
+  content: string;
+  modified: boolean;
+}
+
+let documents: Document[] = [];
+let nextDocId = 1;
+let statusLabel: any;
+let docTabsRef: DocTabs;
+let appRef: App;
+
+// Create a new document
+function createDocument(title?: string): Document {
+  const doc: Document = {
+    id: nextDocId++,
+    title: title || `Untitled ${nextDocId - 1}`,
+    content: '',
+    modified: false
+  };
+  documents.push(doc);
+  return doc;
+}
+
+// Find document by title
+function findDocByTitle(title: string): Document | undefined {
+  return documents.find(d => d.title === title);
+}
+
+// Remove document by title
+function removeDocByTitle(title: string): void {
+  documents = documents.filter(d => d.title !== title);
+}
+
+// Helper to create document content (editor area)
+function createDocumentContent(a: App, doc: Document): void {
+  a.vbox(() => {
+    const editor = a.multilineentry('Start typing...', 'word');
+    editor.setText(doc.content);
+
+    a.hbox(() => {
+      a.button('Mark Modified', () => {
+        doc.modified = true;
+        updateStatus(`${doc.title} marked as modified`);
+      });
+      a.button('Clear', () => {
+        editor.setText('');
+        doc.modified = true;
+        updateStatus(`${doc.title} cleared`);
+      });
+      a.label(`  | ${doc.title}`);
+    });
+  });
+}
+
+// Helper to add a new document tab
+async function addDocumentTab(doc: Document): Promise<void> {
+  await docTabsRef.append(doc.title, () => {
+    createDocumentContent(appRef, doc);
+  }, true);
+}
+
+// Helper to update status
+function updateStatus(message: string): void {
+  if (statusLabel) {
+    statusLabel.setText(`${message} | Documents: ${documents.length}`);
+  }
+}
+
+app({ title: 'Text Editor' }, (a) => {
+  // Store app reference for dynamic tab creation
+  appRef = a;
+
+  a.window({ title: 'Text Editor - DocTabs Demo', width: 800, height: 600 }, (win) => {
+    win.setContent(() => {
+      a.border({
+        // Top toolbar
+        top: () => {
+          a.vbox(() => {
+            a.hbox(() => {
+              a.button('New Document', async () => {
+                const doc = createDocument();
+                await addDocumentTab(doc);
+                updateStatus(`Created: ${doc.title}`);
+              });
+              a.button('Open Sample', async () => {
+                const doc = createDocument(`Sample ${nextDocId - 1}.txt`);
+                doc.content = `This is sample document ${doc.id}.\n\nAdd your content here.\n\nClick the X button on the tab to close this document.`;
+                await addDocumentTab(doc);
+                updateStatus(`Opened: ${doc.title}`);
+              });
+              a.button('Close All', async () => {
+                const confirmed = await win.showConfirm(
+                  'Close All Documents',
+                  'Are you sure you want to close all documents?'
+                );
+                if (confirmed) {
+                  // Remove all tabs from end to start
+                  while (docTabsRef.getTabCount() > 0) {
+                    await docTabsRef.remove(0);
+                  }
+                  documents = [];
+                  updateStatus('All documents closed');
+                }
+              });
+            });
+            a.separator();
+          });
+        },
+        // Main content - DocTabs
+        center: () => {
+          // Create initial documents
+          const doc1 = createDocument('Welcome.txt');
+          doc1.content = 'Welcome to the Text Editor!\n\nThis demo showcases DocTabs - tabs with close buttons.\n\nFeatures:\n- Click the X button on any tab to close it\n- Use "New Document" to add more tabs\n- Each tab has its own text editing area\n\nTry editing this text and switching between tabs!';
+
+          const doc2 = createDocument('Notes.txt');
+          doc2.content = 'Your notes go here...\n\nDocTabs are perfect for:\n- Text editors\n- IDE-style interfaces\n- Document management\n- Any multi-document workflow';
+
+          const doc3 = createDocument('README.md');
+          doc3.content = '# DocTabs Example\n\nDocTabs provides a document-style tab interface\nwith close buttons on each tab.\n\n## API\n\n- doctabs(tabs, options) - Create tabs\n- append(title, builder) - Add new tab\n- remove(index) - Remove tab\n- select(index) - Select tab\n\n## Events\n\n- onClosed(index, title) - Called when tab is closed';
+
+          docTabsRef = a.doctabs(
+            [
+              {
+                title: doc1.title,
+                builder: () => createDocumentContent(a, doc1)
+              },
+              {
+                title: doc2.title,
+                builder: () => createDocumentContent(a, doc2)
+              },
+              {
+                title: doc3.title,
+                builder: () => createDocumentContent(a, doc3)
+              }
+            ],
+            {
+              location: 'top',
+              onClosed: (tabIndex, tabTitle) => {
+                const doc = findDocByTitle(tabTitle);
+                if (doc && doc.modified) {
+                  updateStatus(`Closed (modified): ${tabTitle}`);
+                } else {
+                  updateStatus(`Closed: ${tabTitle}`);
+                }
+                removeDocByTitle(tabTitle);
+              }
+            }
+          );
+        },
+        // Bottom status bar
+        bottom: () => {
+          a.hbox(() => {
+            statusLabel = a.label('Ready | Documents: 3');
+          });
+        }
+      });
+    });
+
+    win.show();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -187,6 +187,16 @@ export class App {
 
   tabs(tabDefinitions: Array<{title: string, builder: () => void}>, location?: 'top' | 'bottom' | 'leading' | 'trailing'): Tabs {
     return new Tabs(this.ctx, tabDefinitions, location);
+  }
+
+  doctabs(
+    tabDefinitions: Array<{title: string, builder: () => void}>,
+    options?: {
+      location?: 'top' | 'bottom' | 'leading' | 'trailing';
+      onClosed?: (tabIndex: number, tabTitle: string) => void;
+    }
+  ): DocTabs {
+    return new DocTabs(this.ctx, tabDefinitions, options);
   }
 
   toolbar(toolbarItems: Array<ToolbarAction | { type: 'separator' | 'spacer' }>): Toolbar {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App, AppOptions } from './app';
 import { Context } from './context';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow } from './widgets';
 import { Window, WindowOptions, ProgressDialog } from './window';
 
 // Global context for the declarative API
@@ -252,6 +252,22 @@ export function tabs(
     throw new Error('tabs() must be called within an app context');
   }
   return new Tabs(globalContext, tabDefinitions, location);
+}
+
+/**
+ * Create a doctabs container (tabs with close buttons)
+ */
+export function doctabs(
+  tabDefinitions: Array<{title: string, builder: () => void}>,
+  options?: {
+    location?: 'top' | 'bottom' | 'leading' | 'trailing';
+    onClosed?: (tabIndex: number, tabTitle: string) => void;
+  }
+): DocTabs {
+  if (!globalContext) {
+    throw new Error('doctabs() must be called within an app context');
+  }
+  return new DocTabs(globalContext, tabDefinitions, options);
 }
 
 /**
@@ -523,7 +539,7 @@ export async function setFontScale(scale: number): Promise<void> {
 }
 
 // Export classes for advanced usage
-export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, Toolbar, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow };
+export { App, Window, ProgressDialog, Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, Slider, ProgressBar, Scroll, Grid, RadioGroup, Split, Tabs, DocTabs, Toolbar, Table, List, Center, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Menu, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow };
 export type { AppOptions, WindowOptions, MenuItem };
 
 // Export theming types

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -1460,6 +1460,133 @@ export class Tabs {
 }
 
 /**
+ * DocTabs container (tabs with close buttons)
+ * Suitable for document-style interfaces like text editors
+ */
+export class DocTabs {
+  private ctx: Context;
+  public id: string;
+  private tabInfos: Array<{title: string, contentId: string}> = [];
+
+  constructor(
+    ctx: Context,
+    tabDefinitions: Array<{title: string, builder: () => void}>,
+    options?: {
+      location?: 'top' | 'bottom' | 'leading' | 'trailing';
+      onClosed?: (tabIndex: number, tabTitle: string) => void;
+    }
+  ) {
+    this.ctx = ctx;
+    this.id = ctx.generateId('doctabs');
+
+    // Build each tab's content
+    const tabs: Array<{title: string, contentId: string}> = [];
+
+    for (const tabDef of tabDefinitions) {
+      ctx.pushContainer();
+      tabDef.builder();
+      const children = ctx.popContainer();
+
+      if (children.length !== 1) {
+        throw new Error(`Tab "${tabDef.title}" must have exactly one child widget`);
+      }
+
+      tabs.push({
+        title: tabDef.title,
+        contentId: children[0]
+      });
+    }
+
+    this.tabInfos = tabs;
+
+    // Create the doctabs container
+    const payload: any = {
+      id: this.id,
+      tabs
+    };
+
+    if (options?.location) {
+      payload.location = options.location;
+    }
+
+    // Register close callback if provided
+    if (options?.onClosed) {
+      const closeCallbackId = ctx.generateId('callback');
+      ctx.bridge.registerEventHandler(closeCallbackId, (data: any) => {
+        options.onClosed!(data.tabIndex, data.tabTitle);
+      });
+      payload.closeCallbackId = closeCallbackId;
+    }
+
+    ctx.bridge.send('createDocTabs', payload);
+    ctx.addToCurrentContainer(this.id);
+  }
+
+  /**
+   * Append a new tab to the DocTabs
+   * @param title Tab title
+   * @param builder Function to build the tab content
+   * @param select Whether to select the new tab after adding
+   */
+  async append(title: string, builder: () => void, select: boolean = true): Promise<void> {
+    this.ctx.pushContainer();
+    builder();
+    const children = this.ctx.popContainer();
+
+    if (children.length !== 1) {
+      throw new Error(`Tab "${title}" must have exactly one child widget`);
+    }
+
+    const contentId = children[0];
+    this.tabInfos.push({ title, contentId });
+
+    await this.ctx.bridge.send('docTabsAppend', {
+      id: this.id,
+      title,
+      contentId,
+      select
+    });
+  }
+
+  /**
+   * Remove a tab by index
+   * @param tabIndex Index of the tab to remove
+   */
+  async remove(tabIndex: number): Promise<void> {
+    await this.ctx.bridge.send('docTabsRemove', {
+      id: this.id,
+      tabIndex
+    });
+    this.tabInfos.splice(tabIndex, 1);
+  }
+
+  /**
+   * Select a tab by index
+   * @param tabIndex Index of the tab to select
+   */
+  async select(tabIndex: number): Promise<void> {
+    await this.ctx.bridge.send('docTabsSelect', {
+      id: this.id,
+      tabIndex
+    });
+  }
+
+  /**
+   * Get the number of tabs
+   */
+  getTabCount(): number {
+    return this.tabInfos.length;
+  }
+
+  /**
+   * Get tab titles
+   */
+  getTabTitles(): string[] {
+    return this.tabInfos.map(t => t.title);
+  }
+}
+
+/**
  * Represents a clickable action item in a Toolbar
  */
 export class ToolbarAction {


### PR DESCRIPTION
Add DocTabs container (Fyne's NewDocTabs) which provides document-style tabs with close buttons, suitable for text editors and IDE-like interfaces.

Features:
- Create DocTabs with initial tabs
- onClosed callback when user closes a tab
- append() to dynamically add new tabs
- remove() to programmatically remove tabs by index
- select() to programmatically select tabs by index
- location option (top, bottom, leading, trailing)
- getTabCount() and getTabTitles() for state inspection

Go bridge:
- handleCreateDocTabs with OnClosed callback support
- handleDocTabsAppend for dynamic tab addition
- handleDocTabsRemove for tab removal
- handleDocTabsSelect for tab selection

TypeScript:
- DocTabs class in widgets.ts with full async API
- doctabs() method in App class and index.ts exports
- Type-safe options with onClosed callback

Demo and tests:
- text-editor.ts: Multi-document editor showcasing DocTabs
- text-editor.test.ts: Comprehensive tests for DocTabs functionality