### PR TITLE
Implement dialog.showEntryD with demo app

### DIFF
--- a/bridge/dialogs.go
+++ b/bridge/dialogs.go
@@ -177,3 +177,39 @@ func (b *Bridge) handleShowFileSave(msg Message) {
 		Success: true,
 	})
 }
+
+func (b *Bridge) handleShowEntryDialog(msg Message) {
+	windowID := msg.Payload["windowId"].(string)
+	title := msg.Payload["title"].(string)
+	message := msg.Payload["message"].(string)
+	callbackID := msg.Payload["callbackId"].(string)
+
+	b.mu.RLock()
+	win, exists := b.windows[windowID]
+	b.mu.RUnlock()
+
+	if !exists {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Window not found",
+		})
+		return
+	}
+
+	dialog.ShowEntryDialog(title, message, func(text string) {
+		b.sendEvent(Event{
+			Type: "callback",
+			Data: map[string]interface{}{
+				"callbackId": callbackID,
+				"text":       text,
+				"cancelled":  text == "",
+			},
+		})
+	}, win)
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+	})
+}

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -126,6 +126,8 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleShowFileOpen(msg)
 	case "showFileSave":
 		b.handleShowFileSave(msg)
+	case "showEntryDialog":
+		b.handleShowEntryDialog(msg)
 	case "resizeWindow":
 		b.handleResizeWindow(msg)
 	case "setWindowTitle":

--- a/examples/rename-dialog.test.ts
+++ b/examples/rename-dialog.test.ts
@@ -1,0 +1,126 @@
+// Test for rename dialog example - demonstrates showEntryDialog
+import { TsyneTest, TestContext } from '../src/index-test';
+import { Label } from '../src';
+import * as path from 'path';
+
+describe('Rename Dialog Example', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should display file list with rename buttons', async () => {
+    interface FileItem {
+      id: number;
+      name: string;
+    }
+
+    const files: FileItem[] = [
+      { id: 1, name: 'document.txt' },
+      { id: 2, name: 'photo.jpg' },
+      { id: 3, name: 'notes.md' },
+    ];
+
+    const fileLabels: Map<number, Label> = new Map();
+    let statusLabel: Label;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'File Renamer', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Click "Rename" to rename a file using the entry dialog:');
+            app.separator();
+
+            for (const file of files) {
+              app.hbox(() => {
+                const label = app.label(file.name);
+                fileLabels.set(file.id, label);
+
+                app.button('Rename', async () => {
+                  const newName = await win.showEntryDialog(
+                    'Rename File',
+                    `Enter new name for "${file.name}":`
+                  );
+
+                  if (newName) {
+                    const oldName = file.name;
+                    file.name = newName;
+                    await label.setText(newName);
+                    await statusLabel.setText(`Renamed "${oldName}" to "${newName}"`);
+                  } else {
+                    await statusLabel.setText('Rename cancelled');
+                  }
+                });
+              });
+            }
+
+            app.separator();
+            statusLabel = app.label('Ready');
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify initial file list is displayed
+    await ctx.expect(ctx.getByExactText('document.txt')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('photo.jpg')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('notes.md')).toBeVisible();
+
+    // Verify at least one rename button is present
+    await ctx.expect(ctx.getByText('Rename')).toBeVisible();
+
+    // Verify status label shows "Ready"
+    await ctx.expect(ctx.getByExactText('Ready')).toBeVisible();
+
+    // Capture screenshot if TAKE_SCREENSHOTS=1
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'rename-dialog.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`📸 Screenshot saved: ${screenshotPath}`);
+    }
+  });
+
+  test('showEntryDialog should return text when confirmed', async () => {
+    let dialogResult: string | null = null;
+    let dialogShown = false;
+
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Entry Dialog Test', width: 300, height: 150 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.button('Show Dialog', async () => {
+              dialogShown = true;
+              dialogResult = await win.showEntryDialog('Test Title', 'Enter some text:');
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // The dialog functionality is tested indirectly through the bridge
+    // In headless mode, we can verify the button triggers the dialog
+    await ctx.getByExactText('Show Dialog').click();
+    await ctx.wait(100);
+
+    // Note: In headless test mode, the entry dialog cannot be interacted with directly
+    // The dialog will be shown but we cannot programmatically type and submit
+    // This test verifies the dialog is invoked without error
+    expect(dialogShown).toBe(true);
+  });
+});

--- a/examples/rename-dialog.ts
+++ b/examples/rename-dialog.ts
@@ -1,0 +1,59 @@
+// Entry dialog demo - demonstrates showEntryDialog for quick text input
+// This example shows a list of files that can be renamed using the entry dialog
+
+import { app, Label } from '../src';
+
+interface FileItem {
+  id: number;
+  name: string;
+}
+
+// Simple file list model
+const files: FileItem[] = [
+  { id: 1, name: 'document.txt' },
+  { id: 2, name: 'photo.jpg' },
+  { id: 3, name: 'notes.md' },
+];
+
+app({ title: 'Rename Dialog Demo' }, (a) => {
+  a.window({ title: 'File Renamer', width: 400, height: 300 }, (win) => {
+    // Track labels so we can update them
+    const fileLabels: Map<number, Label> = new Map();
+    let statusLabel: Label;
+
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Click "Rename" to rename a file using the entry dialog:');
+        a.separator();
+
+        // Render each file with a rename button
+        for (const file of files) {
+          a.hbox(() => {
+            const label = a.label(file.name);
+            fileLabels.set(file.id, label);
+
+            a.button('Rename', async () => {
+              const newName = await win.showEntryDialog(
+                'Rename File',
+                `Enter new name for "${file.name}":`
+              );
+
+              if (newName) {
+                const oldName = file.name;
+                file.name = newName;
+                await label.setText(newName);
+                await statusLabel.setText(`Renamed "${oldName}" to "${newName}"`);
+              } else {
+                await statusLabel.setText('Rename cancelled');
+              }
+            });
+          });
+        }
+
+        a.separator();
+        statusLabel = a.label('Ready');
+      });
+    });
+    win.show();
+  });
+});

--- a/src/window.ts
+++ b/src/window.ts
@@ -46,11 +46,8 @@ export class Window {
       confirm: async (message: string): Promise<boolean> => {
         return await this.showConfirm('Confirm', message);
       },
-      prompt: async (message: string, defaultValue?: string): Promise<string | null> => {
-        // For now, we don't have a prompt dialog in Fyne, so we return null
-        // This can be implemented later with a custom dialog
-        console.log('[PROMPT]', message, defaultValue);
-        return null;
+      prompt: async (message: string, _defaultValue?: string): Promise<string | null> => {
+        return await this.showEntryDialog('Input', message);
       }
     });
 
@@ -196,6 +193,33 @@ export class Window {
         windowId: this.id,
         callbackId,
         filename: filename || 'untitled.txt'
+      });
+    });
+  }
+
+  /**
+   * Shows an entry dialog for quick text input
+   * @param title - Dialog title
+   * @param message - Prompt message shown to user
+   * @returns Promise<string | null> - entered text if submitted, null if cancelled
+   */
+  async showEntryDialog(title: string, message: string): Promise<string | null> {
+    return new Promise((resolve) => {
+      const callbackId = this.ctx.generateId('callback');
+
+      this.ctx.bridge.registerEventHandler(callbackId, (data: any) => {
+        if (data.cancelled || data.text === '') {
+          resolve(null);
+        } else {
+          resolve(data.text);
+        }
+      });
+
+      this.ctx.bridge.send('showEntryDialog', {
+        windowId: this.id,
+        title,
+        message,
+        callbackId
       });
     });
   }


### PR DESCRIPTION
Implements dialog.ShowEntryDialog from Fyne, enabling quick text input dialogs like rename prompts. Also updates the global prompt() handler to use this new dialog instead of returning null.

Changes:
- bridge/dialogs.go: Add handleShowEntryDialog handler
- bridge/main.go: Register showEntryDialog message handler
- src/window.ts: Add showEntryDialog method and update prompt handler
- examples/rename-dialog.ts: Demo app showing file renaming use case
- examples/rename-dialog.test.ts: Tests for the demo app