### PR TITLE
Implement dialog.showNew feature with demo

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -126,6 +126,10 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleShowFileOpen(msg)
 	case "showFileSave":
 		b.handleShowFileSave(msg)
+	case "showCustom":
+		b.handleShowCustom(msg)
+	case "showCustomConfirm":
+		b.handleShowCustomConfirm(msg)
 	case "resizeWindow":
 		b.handleResizeWindow(msg)
 	case "setWindowTitle":

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -269,6 +269,22 @@ Tsyne provides common dialog methods on the Window class for user interactions:
   - `filename`: Default filename (optional, defaults to 'untitled.txt')
   - Returns: `Promise<string | null>` - selected file path or null if cancelled
 
+### Custom Dialogs
+
+- **`window.showCustom(title, contentBuilder, options?)`**: Show a custom dialog with arbitrary content
+  - `title`: Dialog title
+  - `contentBuilder`: Function that builds the dialog content using the app context
+  - `options.dismissText`: Text for the dismiss button (optional, default 'Close')
+  - `options.onClosed`: Callback when dialog is closed (optional)
+  - Returns: `Promise<void>` - resolves when dialog is closed
+
+- **`window.showCustomConfirm(title, contentBuilder, options?)`**: Show a custom dialog with confirm/cancel buttons
+  - `title`: Dialog title
+  - `contentBuilder`: Function that builds the dialog content using the app context
+  - `options.confirmText`: Text for the confirm button (optional, default 'OK')
+  - `options.dismissText`: Text for the dismiss button (optional, default 'Cancel')
+  - Returns: `Promise<boolean>` - true if confirmed, false if cancelled
+
 ### Dialog Examples
 
 ```typescript
@@ -297,6 +313,28 @@ if (filePath) {
 const savePath = await win.showFileSave('document.txt');
 if (savePath) {
   console.log('Save to:', savePath);
+}
+
+// Custom dialog with arbitrary content
+await win.showCustom('About', () => {
+  app.vbox(() => {
+    app.label('My Application v1.0');
+    app.label('Built with Tsyne');
+  });
+}, { dismissText: 'OK' });
+
+// Custom confirm dialog
+const accepted = await win.showCustomConfirm('License Agreement', () => {
+  app.vbox(() => {
+    app.label('Terms and Conditions');
+    app.label('Do you accept the license?');
+  });
+}, {
+  confirmText: 'Accept',
+  dismissText: 'Decline'
+});
+if (accepted) {
+  // User accepted the license
 }
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@ This document tracks Fyne features **not yet implemented** in Tsyne, with sugges
 | **ColorPicker** | `dialog.ShowColorPicker` | Color selection | `drawing-app.ts` - Simple paint program |
 | **EntryDialog** | `dialog.ShowEntryDialog` | Quick text input | `rename-dialog.ts` - Rename file/item |
 | **FormDialog** | `dialog.ShowForm` | Form in dialog | `new-contact.ts` - Add contact form dialog |
-| **CustomDialog** | `dialog.NewCustom` | Custom dialog content | `about-dialog.ts` - Custom about box |
+| ~~**CustomDialog**~~ | ~~`dialog.NewCustom`~~ | ~~Custom dialog content~~ | ~~`about-dialog.ts` - Custom about box~~ | **IMPLEMENTED** |
 | **ProgressDialog** | `dialog.ShowProgress` | Progress in dialog | `download-manager.ts` - Download with progress |
 
 ---

--- a/examples/about-dialog.test.ts
+++ b/examples/about-dialog.test.ts
@@ -1,0 +1,111 @@
+// Test for custom dialog functionality
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+describe('Custom Dialog', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should open custom dialog and show content', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Custom Dialog Test', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Main Window');
+            app.button('Open Dialog', async () => {
+              await win.showCustom('Test Dialog', () => {
+                app.vbox(() => {
+                  app.label('Dialog Content');
+                  app.label('This is custom content');
+                });
+              }, {
+                dismissText: 'Close'
+              });
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Main window should be visible
+    await ctx.expect(ctx.getByExactText('Main Window')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Open Dialog')).toBeVisible();
+
+    // Capture screenshot before dialog
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'about-dialog-before.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+
+    // Click to open dialog
+    await ctx.getByExactText('Open Dialog').click();
+    await ctx.wait(300);
+
+    // Dialog content should be visible
+    // Note: The dialog's Close button is a Fyne internal widget, not accessible via our test framework
+    await ctx.expect(ctx.getByExactText('Dialog Content')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('This is custom content')).toBeVisible();
+
+    // Capture screenshot with dialog open
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'about-dialog-open.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+  });
+
+  test('should open custom confirm dialog and show content', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Confirm Dialog Test', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Status: Waiting');
+            app.button('Open Confirm', async () => {
+              await win.showCustomConfirm('Confirm Action', () => {
+                app.vbox(() => {
+                  app.label('Do you want to proceed?');
+                  app.label('This action requires confirmation.');
+                });
+              }, {
+                confirmText: 'Yes',
+                dismissText: 'No'
+              });
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Initial state
+    await ctx.expect(ctx.getByExactText('Status: Waiting')).toBeVisible();
+
+    // Open dialog
+    await ctx.getByExactText('Open Confirm').click();
+    await ctx.wait(300);
+
+    // Dialog content should show
+    // Note: The Yes/No buttons are Fyne internal widgets, not accessible via our test framework
+    await ctx.expect(ctx.getByExactText('Do you want to proceed?')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('This action requires confirmation.')).toBeVisible();
+  });
+});

--- a/examples/about-dialog.ts
+++ b/examples/about-dialog.ts
@@ -1,0 +1,146 @@
+// About Dialog - Demonstrates custom dialogs with arbitrary content
+// This example shows how to use showCustom() and showCustomConfirm()
+
+import { app } from '../src';
+
+const APP_NAME = 'My Awesome App';
+const APP_VERSION = '1.0.0';
+const APP_DESCRIPTION = 'A demonstration of custom dialogs in Tsyne. Custom dialogs allow you to display arbitrary widget content in a modal dialog.';
+
+app({ title: 'About Dialog Demo' }, (a) => {
+  a.window({ title: 'About Dialog Demo', width: 400, height: 300 }, (win) => {
+    let statusLabel: any;
+
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Custom Dialog Examples', undefined, 'center', undefined, { bold: true });
+        a.separator();
+
+        statusLabel = a.label('Click a button to see a custom dialog');
+
+        a.separator();
+
+        // Button to show a simple About dialog
+        a.button('Show About Dialog', async () => {
+          await win.showCustom('About ' + APP_NAME, () => {
+            a.vbox(() => {
+              a.center(() => {
+                a.vbox(() => {
+                  a.label(APP_NAME, undefined, 'center', undefined, { bold: true });
+                  a.label(`Version ${APP_VERSION}`, undefined, 'center');
+                  a.separator();
+                  a.label(APP_DESCRIPTION, undefined, 'center', 'word');
+                  a.separator();
+                  a.label('Built with Tsyne + Fyne', undefined, 'center', undefined, { italic: true });
+                });
+              });
+            });
+          });
+          await statusLabel.setText('About dialog was closed');
+        });
+
+        // Button to show a custom confirm dialog
+        a.button('Show License Agreement', async () => {
+          const accepted = await win.showCustomConfirm(
+            'License Agreement',
+            () => {
+              a.vbox(() => {
+                a.label('End User License Agreement', undefined, 'center', undefined, { bold: true });
+                a.separator();
+                a.scroll(() => {
+                  a.vbox(() => {
+                    a.label('Terms and Conditions:', undefined, 'leading', undefined, { bold: true });
+                    a.label('1. You may use this software for any purpose.');
+                    a.label('2. You may modify this software.');
+                    a.label('3. You must include this license.');
+                    a.label('4. The software is provided "as is".');
+                    a.separator();
+                    a.label('By clicking Accept, you agree to these terms.');
+                  });
+                });
+              });
+            },
+            {
+              confirmText: 'Accept',
+              dismissText: 'Decline'
+            }
+          );
+
+          if (accepted) {
+            await statusLabel.setText('License agreement accepted!');
+          } else {
+            await statusLabel.setText('License agreement declined');
+          }
+        });
+
+        // Button to show a feature dialog with rich content
+        a.button('Show Features', async () => {
+          await win.showCustom(
+            'Features',
+            () => {
+              a.vbox(() => {
+                a.label('Key Features', undefined, 'center', undefined, { bold: true });
+                a.separator();
+                a.accordion([
+                  {
+                    title: 'Custom Content',
+                    builder: () => {
+                      a.label('Create dialogs with any widget content - labels, buttons, forms, and more!');
+                    }
+                  },
+                  {
+                    title: 'Callbacks',
+                    builder: () => {
+                      a.label('Get notified when dialogs are closed or confirmed.');
+                    }
+                  },
+                  {
+                    title: 'Customizable Buttons',
+                    builder: () => {
+                      a.label('Set custom text for confirm and dismiss buttons.');
+                    }
+                  }
+                ]);
+              });
+            },
+            { dismissText: 'Got it!' }
+          );
+          await statusLabel.setText('Features dialog closed');
+        });
+
+        a.separator();
+
+        // Button to show a settings-like dialog
+        a.button('Edit Settings', async () => {
+          const confirmed = await win.showCustomConfirm(
+            'Settings',
+            () => {
+              a.vbox(() => {
+                a.checkbox('Enable notifications', () => {});
+                a.checkbox('Dark mode', () => {});
+                a.checkbox('Auto-save', () => {});
+                a.separator();
+                a.hbox(() => {
+                  a.label('Language:');
+                  a.select(['English', 'Spanish', 'French', 'German'], () => {});
+                });
+              });
+            },
+            {
+              confirmText: 'Save',
+              dismissText: 'Cancel'
+            }
+          );
+
+          if (confirmed) {
+            await statusLabel.setText('Settings saved!');
+          } else {
+            await statusLabel.setText('Settings cancelled');
+          }
+        });
+      });
+    });
+
+    win.show();
+  });
+});


### PR DESCRIPTION
Implement showCustom() and showCustomConfirm() methods on Window class:
- showCustom: Display modal dialog with arbitrary widget content
- showCustomConfirm: Custom dialog with confirm/cancel buttons

Includes Go bridge handlers, TypeScript API, demo app (about-dialog.ts), tests, and API documentation updates.