### PR TITLE
Implement Icon widget display component

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -347,6 +347,21 @@ func (b *Bridge) handleMessage(msg Message) {
 		b.handleCreatePopup(msg)
 	case "showPopup":
 		b.handleShowPopup(msg)
+	// Icon widget
+	case "createIcon":
+		b.handleCreateIcon(msg)
+	case "setIconResource":
+		b.handleSetIconResource(msg)
+	// FileIcon widget
+	case "createFileIcon":
+		b.handleCreateFileIcon(msg)
+	case "setFileIconURI":
+		b.handleSetFileIconURI(msg)
+	case "setFileIconSelected":
+		b.handleSetFileIconSelected(msg)
+	// Calendar widget
+	case "createCalendar":
+		b.handleCreateCalendar(msg)
 	case "hidePopup":
 		b.handleHidePopup(msg)
 	case "movePopup":

--- a/bridge/widget_creators.go
+++ b/bridge/widget_creators.go
@@ -3862,3 +3862,440 @@ func (b *Bridge) handleMovePopup(msg Message) {
 		Success: true,
 	})
 }
+
+// ============================================================================
+// Icon Widget - Theme icon display
+// ============================================================================
+
+func (b *Bridge) handleCreateIcon(msg Message) {
+	widgetID := msg.Payload["id"].(string)
+	iconName := msg.Payload["iconName"].(string)
+
+	// Map icon name string to Fyne theme icon
+	resource := mapIconNameToResource(iconName)
+	if resource == nil {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   fmt.Sprintf("Unknown icon name: %s", iconName),
+		})
+		return
+	}
+
+	icon := widget.NewIcon(resource)
+
+	b.mu.Lock()
+	b.widgets[widgetID] = icon
+	b.widgetMeta[widgetID] = WidgetMetadata{Type: "icon", Text: iconName}
+	b.mu.Unlock()
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+		Result:  map[string]interface{}{"widgetId": widgetID},
+	})
+}
+
+func (b *Bridge) handleSetIconResource(msg Message) {
+	widgetID := msg.Payload["widgetId"].(string)
+	iconName := msg.Payload["iconName"].(string)
+
+	b.mu.RLock()
+	w, exists := b.widgets[widgetID]
+	b.mu.RUnlock()
+
+	if !exists {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget not found",
+		})
+		return
+	}
+
+	icon, ok := w.(*widget.Icon)
+	if !ok {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget is not an Icon",
+		})
+		return
+	}
+
+	resource := mapIconNameToResource(iconName)
+	if resource == nil {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   fmt.Sprintf("Unknown icon name: %s", iconName),
+		})
+		return
+	}
+
+	icon.SetResource(resource)
+
+	b.mu.Lock()
+	b.widgetMeta[widgetID] = WidgetMetadata{Type: "icon", Text: iconName}
+	b.mu.Unlock()
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+	})
+}
+
+// mapIconNameToResource maps icon name strings to Fyne theme resources
+func mapIconNameToResource(name string) fyne.Resource {
+	switch name {
+	// Standard icons
+	case "cancel":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconCancel)
+	case "confirm":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconConfirm)
+	case "delete":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDelete)
+	case "search":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconSearch)
+	case "searchReplace":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconSearchReplace)
+
+	// Media icons
+	case "mediaPlay":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaPlay)
+	case "mediaPause":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaPause)
+	case "mediaStop":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaStop)
+	case "mediaRecord":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaRecord)
+	case "mediaReplay":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaReplay)
+	case "mediaSkipNext":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaSkipNext)
+	case "mediaSkipPrevious":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaSkipPrevious)
+	case "mediaFastForward":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaFastForward)
+	case "mediaFastRewind":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMediaFastRewind)
+
+	// Navigation icons
+	case "home":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconHome)
+	case "menu":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMenu)
+	case "menuExpand":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMenuExpand)
+	case "moveDown":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMoveDown)
+	case "moveUp":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMoveUp)
+	case "navigate":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconNavigate)
+	case "arrowBack":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconArrowBack)
+	case "arrowForward":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconArrowForward)
+
+	// File icons
+	case "file":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFile)
+	case "fileApplication":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFileApplication)
+	case "fileAudio":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFileAudio)
+	case "fileImage":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFileImage)
+	case "fileText":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFileText)
+	case "fileVideo":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFileVideo)
+	case "folder":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFolder)
+	case "folderNew":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFolderNew)
+	case "folderOpen":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconFolderOpen)
+
+	// Document icons
+	case "document":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDocument)
+	case "documentCreate":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDocumentCreate)
+	case "documentSave":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDocumentSave)
+	case "documentPrint":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDocumentPrint)
+
+	// Content icons
+	case "content":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContent)
+	case "contentAdd":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentAdd)
+	case "contentClear":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentClear)
+	case "contentCopy":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentCopy)
+	case "contentCut":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentCut)
+	case "contentPaste":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentPaste)
+	case "contentRedo":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentRedo)
+	case "contentRemove":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentRemove)
+	case "contentUndo":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconContentUndo)
+
+	// View icons
+	case "viewFullScreen":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewFullScreen)
+	case "viewRefresh":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewRefresh)
+	case "viewZoomFit":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewZoomFit)
+	case "viewZoomIn":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewZoomIn)
+	case "viewZoomOut":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewZoomOut)
+	case "viewRestore":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconViewRestore)
+	case "visibility":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconVisibility)
+	case "visibilityOff":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconVisibilityOff)
+
+	// Status icons
+	case "info":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconInfo)
+	case "question":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconQuestion)
+	case "warning":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconWarning)
+	case "error":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconError)
+	case "help":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconHelp)
+	case "history":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconHistory)
+
+	// Action icons
+	case "settings":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconSettings)
+	case "mailAttachment":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailAttachment)
+	case "mailCompose":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailCompose)
+	case "mailForward":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailForward)
+	case "mailReply":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailReply)
+	case "mailReplyAll":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailReplyAll)
+	case "mailSend":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconMailSend)
+
+	// Volume icons
+	case "volumeDown":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconVolumeDown)
+	case "volumeMute":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconVolumeMute)
+	case "volumeUp":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconVolumeUp)
+
+	// Misc icons
+	case "download":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconDownload)
+	case "upload":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconUpload)
+	case "computer":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconComputer)
+	case "storage":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconStorage)
+	case "account":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconAccount)
+	case "login":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconLogin)
+	case "logout":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconLogout)
+	case "list":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconList)
+	case "grid":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconGrid)
+	case "colorChromatic":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconColorChromatic)
+	case "colorPalette":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconColorPalette)
+
+	// Checkbox icons
+	case "checkButtonChecked":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconCheckButtonChecked)
+	case "checkButton":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconCheckButton)
+	case "radioButton":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconRadioButton)
+	case "radioButtonChecked":
+		return fyne.CurrentApp().Settings().Theme().Icon(fyne.ThemeIconRadioButtonChecked)
+
+	default:
+		return nil
+	}
+}
+
+// ============================================================================
+// FileIcon Widget - File type icon
+// ============================================================================
+
+func (b *Bridge) handleCreateFileIcon(msg Message) {
+	widgetID := msg.Payload["id"].(string)
+	path := msg.Payload["path"].(string)
+
+	// Create URI from path
+	uri := fyne.CurrentApp().Driver().LegacyStorage().Create(path)
+	if uri == nil {
+		// Fallback: try to create a file URI
+		uri = fyne.CurrentApp().Driver().LegacyStorage().Create("file://" + path)
+	}
+
+	var fileIcon *widget.FileIcon
+	if uri != nil {
+		fileIcon = widget.NewFileIcon(uri)
+	} else {
+		// Create with nil URI - will show generic file icon
+		fileIcon = widget.NewFileIcon(nil)
+	}
+
+	b.mu.Lock()
+	b.widgets[widgetID] = fileIcon
+	b.widgetMeta[widgetID] = WidgetMetadata{Type: "fileicon", Text: path}
+	b.mu.Unlock()
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+		Result:  map[string]interface{}{"widgetId": widgetID},
+	})
+}
+
+func (b *Bridge) handleSetFileIconURI(msg Message) {
+	widgetID := msg.Payload["widgetId"].(string)
+	path := msg.Payload["path"].(string)
+
+	b.mu.RLock()
+	w, exists := b.widgets[widgetID]
+	b.mu.RUnlock()
+
+	if !exists {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget not found",
+		})
+		return
+	}
+
+	fileIcon, ok := w.(*widget.FileIcon)
+	if !ok {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget is not a FileIcon",
+		})
+		return
+	}
+
+	uri := fyne.CurrentApp().Driver().LegacyStorage().Create(path)
+	fileIcon.SetURI(uri)
+
+	b.mu.Lock()
+	b.widgetMeta[widgetID] = WidgetMetadata{Type: "fileicon", Text: path}
+	b.mu.Unlock()
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+	})
+}
+
+func (b *Bridge) handleSetFileIconSelected(msg Message) {
+	widgetID := msg.Payload["widgetId"].(string)
+	selected := msg.Payload["selected"].(bool)
+
+	b.mu.RLock()
+	w, exists := b.widgets[widgetID]
+	b.mu.RUnlock()
+
+	if !exists {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget not found",
+		})
+		return
+	}
+
+	fileIcon, ok := w.(*widget.FileIcon)
+	if !ok {
+		b.sendResponse(Response{
+			ID:      msg.ID,
+			Success: false,
+			Error:   "Widget is not a FileIcon",
+		})
+		return
+	}
+
+	fileIcon.SetSelected(selected)
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+	})
+}
+
+// ============================================================================
+// Calendar Widget - Standalone calendar
+// ============================================================================
+
+func (b *Bridge) handleCreateCalendar(msg Message) {
+	widgetID := msg.Payload["id"].(string)
+	callbackID, hasCallback := msg.Payload["callbackId"].(string)
+
+	// Parse initial date if provided
+	initialTime := time.Now()
+	if initialDate, ok := msg.Payload["date"].(string); ok && initialDate != "" {
+		if t, err := time.Parse("2006-01-02", initialDate); err == nil {
+			initialTime = t
+		}
+	}
+
+	var calendar *widget.Calendar
+	if hasCallback {
+		calendar = widget.NewCalendar(initialTime, func(t time.Time) {
+			b.sendEvent(Event{
+				Type:     "callback",
+				WidgetID: widgetID,
+				Data: map[string]interface{}{
+					"callbackId": callbackID,
+					"date":       t.Format("2006-01-02"),
+				},
+			})
+		})
+	} else {
+		calendar = widget.NewCalendar(initialTime, func(t time.Time) {})
+	}
+
+	b.mu.Lock()
+	b.widgets[widgetID] = calendar
+	b.widgetMeta[widgetID] = WidgetMetadata{Type: "calendar", Text: initialTime.Format("2006-01-02")}
+	if hasCallback {
+		b.callbacks[widgetID] = callbackID
+	}
+	b.mu.Unlock()
+
+	b.sendResponse(Response{
+		ID:      msg.ID,
+		Success: true,
+		Result:  map[string]interface{}{"widgetId": widgetID},
+	})
+}

--- a/examples/appointment-scheduler.ts
+++ b/examples/appointment-scheduler.ts
@@ -1,0 +1,103 @@
+/**
+ * Appointment Scheduler - Date selection UI with Calendar widget
+ *
+ * This example demonstrates the standalone Calendar widget which shows
+ * a full calendar month view for inline date selection.
+ *
+ * Run: npx ts-node examples/appointment-scheduler.ts
+ */
+import { app } from '../src/index';
+
+// Sample appointments
+interface Appointment {
+  date: string;
+  time: string;
+  title: string;
+}
+
+const appointments: Appointment[] = [
+  { date: '2025-11-25', time: '09:00', title: 'Team Meeting' },
+  { date: '2025-11-25', time: '14:00', title: 'Project Review' },
+  { date: '2025-11-27', time: '10:30', title: 'Client Call' },
+  { date: '2025-11-28', time: '15:00', title: 'Training Session' },
+];
+
+app({ title: 'Tsyne Appointment Scheduler' }, (a) => {
+  a.window({ title: 'Appointment Scheduler', width: 700, height: 500 }, (win) => {
+    let selectedDate = new Date().toISOString().split('T')[0]; // Today's date
+    let dateLabel: any;
+    let appointmentContainer: any;
+
+    // Function to get appointments for a date
+    const getAppointmentsForDate = (date: string): Appointment[] => {
+      return appointments.filter(apt => apt.date === date);
+    };
+
+    // Function to update the appointment list display
+    const updateAppointmentList = async (date: string) => {
+      if (dateLabel) {
+        await dateLabel.setText(`Appointments for ${date}`);
+      }
+    };
+
+    win.setContent(() => {
+      a.hbox(() => {
+        // Left side: Calendar
+        a.vbox(() => {
+          a.label('Select a Date', undefined, 'center', undefined, { bold: true });
+          a.separator();
+
+          // Standalone calendar widget
+          a.calendar(selectedDate, async (date) => {
+            selectedDate = date;
+            await updateAppointmentList(date);
+            console.log(`Selected date: ${date}`);
+          });
+        });
+
+        a.separator();
+
+        // Right side: Appointments list
+        a.vbox(() => {
+          dateLabel = a.label(`Appointments for ${selectedDate}`, undefined, 'center', undefined, { bold: true });
+          a.separator();
+
+          a.scroll(() => {
+            appointmentContainer = a.vbox(() => {
+              // Show sample appointments
+              const todayAppointments = getAppointmentsForDate(selectedDate);
+              if (todayAppointments.length === 0) {
+                a.label('No appointments for this date');
+              } else {
+                for (const apt of todayAppointments) {
+                  a.card(apt.title, apt.time, () => {
+                    a.hbox(() => {
+                      a.icon('info');
+                      a.label(`${apt.time} - ${apt.title}`);
+                    });
+                  });
+                }
+              }
+            });
+          });
+
+          a.separator();
+
+          // Action buttons
+          a.hbox(() => {
+            a.button('Add Appointment', () => {
+              console.log(`Adding appointment for ${selectedDate}`);
+            });
+            a.button('View All', () => {
+              console.log('Viewing all appointments');
+              appointments.forEach(apt => {
+                console.log(`  ${apt.date} ${apt.time}: ${apt.title}`);
+              });
+            });
+          });
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/examples/file-browser.ts
+++ b/examples/file-browser.ts
@@ -1,0 +1,97 @@
+/**
+ * File Browser - Simple file browser with icons
+ *
+ * This example demonstrates the FileIcon widget which displays
+ * appropriate icons based on file type/extension.
+ *
+ * Run: npx ts-node examples/file-browser.ts
+ */
+import { app } from '../src/index';
+
+// Sample file entries with different types
+const sampleFiles = [
+  { name: 'Documents', path: '/home/user/Documents', isFolder: true },
+  { name: 'Pictures', path: '/home/user/Pictures', isFolder: true },
+  { name: 'Music', path: '/home/user/Music', isFolder: true },
+  { name: 'Videos', path: '/home/user/Videos', isFolder: true },
+  { name: 'report.pdf', path: '/home/user/report.pdf', isFolder: false },
+  { name: 'notes.txt', path: '/home/user/notes.txt', isFolder: false },
+  { name: 'photo.jpg', path: '/home/user/photo.jpg', isFolder: false },
+  { name: 'song.mp3', path: '/home/user/song.mp3', isFolder: false },
+  { name: 'movie.mp4', path: '/home/user/movie.mp4', isFolder: false },
+  { name: 'script.py', path: '/home/user/script.py', isFolder: false },
+  { name: 'app.exe', path: '/home/user/app.exe', isFolder: false },
+  { name: 'data.json', path: '/home/user/data.json', isFolder: false },
+  { name: 'styles.css', path: '/home/user/styles.css', isFolder: false },
+  { name: 'index.html', path: '/home/user/index.html', isFolder: false },
+  { name: 'README.md', path: '/home/user/README.md', isFolder: false },
+];
+
+app({ title: 'Tsyne File Browser' }, (a) => {
+  a.window({ title: 'File Browser', width: 600, height: 500 }, (win) => {
+    let selectedFile: string | null = null;
+    let statusLabel: any;
+
+    win.setContent(() => {
+      a.vbox(() => {
+        // Header with current path
+        a.hbox(() => {
+          a.icon('folder');
+          a.label('/home/user', undefined, 'leading', undefined, { bold: true });
+        });
+
+        a.separator();
+
+        // File list
+        a.scroll(() => {
+          a.vbox(() => {
+            for (const file of sampleFiles) {
+              a.hbox(() => {
+                // File icon based on path/type
+                const fileIcon = a.fileicon(file.path);
+
+                // File name as clickable button
+                a.button(file.name, async () => {
+                  // Deselect previous
+                  selectedFile = file.path;
+                  await fileIcon.setSelected(true);
+
+                  // Update status
+                  if (statusLabel) {
+                    await statusLabel.setText(`Selected: ${file.name}`);
+                  }
+                });
+              });
+            }
+          });
+        });
+
+        a.separator();
+
+        // Status bar
+        a.hbox(() => {
+          a.icon('info');
+          statusLabel = a.label('Click a file to select it');
+        });
+
+        // Action buttons
+        a.hbox(() => {
+          a.button('Open', () => {
+            if (selectedFile) {
+              console.log(`Opening: ${selectedFile}`);
+            }
+          });
+          a.button('Delete', () => {
+            if (selectedFile) {
+              console.log(`Deleting: ${selectedFile}`);
+            }
+          });
+          a.button('New Folder', () => {
+            console.log('Creating new folder...');
+          });
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/examples/icon-gallery.ts
+++ b/examples/icon-gallery.ts
@@ -1,0 +1,93 @@
+/**
+ * Icon Gallery - Display all available Fyne theme icons
+ *
+ * This example demonstrates the Icon widget which displays themed icons
+ * that automatically adapt to light/dark system themes.
+ *
+ * Run: npx ts-node examples/icon-gallery.ts
+ */
+import { app } from '../src/index';
+import { ThemeIconName } from '../src/app';
+
+// All available theme icon names organized by category
+const iconCategories: { [category: string]: ThemeIconName[] } = {
+  'Standard': [
+    'cancel', 'confirm', 'delete', 'search', 'searchReplace'
+  ],
+  'Media': [
+    'mediaPlay', 'mediaPause', 'mediaStop', 'mediaRecord', 'mediaReplay',
+    'mediaSkipNext', 'mediaSkipPrevious', 'mediaFastForward', 'mediaFastRewind'
+  ],
+  'Navigation': [
+    'home', 'menu', 'menuExpand', 'moveDown', 'moveUp', 'navigate',
+    'arrowBack', 'arrowForward'
+  ],
+  'Files': [
+    'file', 'fileApplication', 'fileAudio', 'fileImage', 'fileText', 'fileVideo',
+    'folder', 'folderNew', 'folderOpen'
+  ],
+  'Documents': [
+    'document', 'documentCreate', 'documentSave', 'documentPrint'
+  ],
+  'Content': [
+    'content', 'contentAdd', 'contentClear', 'contentCopy', 'contentCut',
+    'contentPaste', 'contentRedo', 'contentRemove', 'contentUndo'
+  ],
+  'View': [
+    'viewFullScreen', 'viewRefresh', 'viewZoomFit', 'viewZoomIn', 'viewZoomOut',
+    'viewRestore', 'visibility', 'visibilityOff'
+  ],
+  'Status': [
+    'info', 'question', 'warning', 'error', 'help', 'history'
+  ],
+  'Actions': [
+    'settings', 'mailAttachment', 'mailCompose', 'mailForward', 'mailReply',
+    'mailReplyAll', 'mailSend'
+  ],
+  'Volume': [
+    'volumeDown', 'volumeMute', 'volumeUp'
+  ],
+  'Misc': [
+    'download', 'upload', 'computer', 'storage', 'account', 'login', 'logout',
+    'list', 'grid', 'colorChromatic', 'colorPalette'
+  ],
+  'Checkboxes': [
+    'checkButtonChecked', 'checkButton', 'radioButton', 'radioButtonChecked'
+  ]
+};
+
+app({ title: 'Tsyne Icon Gallery' }, (a) => {
+  a.window({ title: 'Theme Icon Gallery', width: 800, height: 600 }, (win) => {
+    win.setContent(() => {
+      a.scroll(() => {
+        a.vbox(() => {
+          a.label('Fyne Theme Icons', undefined, 'center', undefined, { bold: true });
+          a.label('Click any icon to see its name', undefined, 'center');
+          a.separator();
+
+          // Create a section for each category
+          for (const [category, icons] of Object.entries(iconCategories)) {
+            a.vbox(() => {
+              a.label(`${category}`, undefined, 'leading', undefined, { bold: true });
+
+              // Use grid to display icons in rows
+              a.gridwrap(80, 80, () => {
+                for (const iconName of icons) {
+                  a.vbox(() => {
+                    a.center(() => {
+                      a.icon(iconName);
+                    });
+                    a.label(iconName, undefined, 'center');
+                  });
+                }
+              });
+
+              a.separator();
+            });
+          }
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,8 @@
 import { BridgeConnection } from './fynebridge';
 import { Context } from './context';
 import { Window, WindowOptions } from './window';
-import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, SelectEntry, Slider, ProgressBar, ProgressBarInfinite, Activity, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Padded, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, AdaptiveGrid, Popup, ThemeOverride, DateEntry, TextGrid, TextGridOptions, TextGridStyle, Navigation, NavigationOptions } from './widgets';
-export type { TextGridOptions, TextGridStyle, NavigationOptions };
+import { Button, Label, Entry, MultiLineEntry, PasswordEntry, Separator, Hyperlink, VBox, HBox, Checkbox, Select, SelectEntry, Slider, ProgressBar, ProgressBarInfinite, Activity, Scroll, Grid, RadioGroup, CheckGroup, Split, Tabs, DocTabs, Toolbar, ToolbarAction, Table, List, Center, Max, Card, Accordion, Form, Tree, RichText, Image, Border, GridWrap, Padded, Menu, MenuItem, CanvasLine, CanvasCircle, CanvasRectangle, CanvasText, CanvasRaster, CanvasLinearGradient, Clip, InnerWindow, AdaptiveGrid, Popup, ThemeOverride, DateEntry, TextGrid, TextGridOptions, TextGridStyle, Navigation, NavigationOptions, Icon, FileIcon, Calendar, ThemeIconName } from './widgets';
+export type { TextGridOptions, TextGridStyle, NavigationOptions, ThemeIconName };
 import { initializeGlobals } from './globals';
 import { ResourceManager } from './resources';
 
@@ -202,6 +202,18 @@ export class App {
 
   dateentry(initialDate?: string, onChanged?: (date: string) => void): DateEntry {
     return new DateEntry(this.ctx, initialDate, onChanged);
+  }
+
+  calendar(initialDate?: string, onSelected?: (date: string) => void): Calendar {
+    return new Calendar(this.ctx, initialDate, onSelected);
+  }
+
+  icon(iconName: ThemeIconName): Icon {
+    return new Icon(this.ctx, iconName);
+  }
+
+  fileicon(path: string): FileIcon {
+    return new FileIcon(this.ctx, path);
   }
 
   hsplit(leadingBuilder: () => void, trailingBuilder: () => void, offset?: number): Split {

--- a/src/widgets/display.ts
+++ b/src/widgets/display.ts
@@ -2,6 +2,114 @@ import { Context } from '../context';
 import { Widget } from './base';
 
 /**
+ * Available theme icon names for the Icon widget
+ */
+export type ThemeIconName =
+  // Standard icons
+  | 'cancel' | 'confirm' | 'delete' | 'search' | 'searchReplace'
+  // Media icons
+  | 'mediaPlay' | 'mediaPause' | 'mediaStop' | 'mediaRecord' | 'mediaReplay'
+  | 'mediaSkipNext' | 'mediaSkipPrevious' | 'mediaFastForward' | 'mediaFastRewind'
+  // Navigation icons
+  | 'home' | 'menu' | 'menuExpand' | 'moveDown' | 'moveUp' | 'navigate'
+  | 'arrowBack' | 'arrowForward'
+  // File icons
+  | 'file' | 'fileApplication' | 'fileAudio' | 'fileImage' | 'fileText' | 'fileVideo'
+  | 'folder' | 'folderNew' | 'folderOpen'
+  // Document icons
+  | 'document' | 'documentCreate' | 'documentSave' | 'documentPrint'
+  // Content icons
+  | 'content' | 'contentAdd' | 'contentClear' | 'contentCopy' | 'contentCut'
+  | 'contentPaste' | 'contentRedo' | 'contentRemove' | 'contentUndo'
+  // View icons
+  | 'viewFullScreen' | 'viewRefresh' | 'viewZoomFit' | 'viewZoomIn' | 'viewZoomOut'
+  | 'viewRestore' | 'visibility' | 'visibilityOff'
+  // Status icons
+  | 'info' | 'question' | 'warning' | 'error' | 'help' | 'history'
+  // Action icons
+  | 'settings' | 'mailAttachment' | 'mailCompose' | 'mailForward' | 'mailReply'
+  | 'mailReplyAll' | 'mailSend'
+  // Volume icons
+  | 'volumeDown' | 'volumeMute' | 'volumeUp'
+  // Misc icons
+  | 'download' | 'upload' | 'computer' | 'storage' | 'account' | 'login' | 'logout'
+  | 'list' | 'grid' | 'colorChromatic' | 'colorPalette'
+  // Checkbox icons
+  | 'checkButtonChecked' | 'checkButton' | 'radioButton' | 'radioButtonChecked';
+
+/**
+ * Icon widget - displays a theme icon
+ * Shows standard Fyne theme icons that automatically adapt to light/dark themes
+ */
+export class Icon extends Widget {
+  private iconName: ThemeIconName;
+
+  constructor(ctx: Context, iconName: ThemeIconName) {
+    const id = ctx.generateId('icon');
+    super(ctx, id);
+    this.iconName = iconName;
+
+    ctx.bridge.send('createIcon', { id, iconName });
+    ctx.addToCurrentContainer(id);
+  }
+
+  /**
+   * Change the displayed icon
+   * @param iconName The name of the theme icon to display
+   */
+  async setResource(iconName: ThemeIconName): Promise<void> {
+    this.iconName = iconName;
+    await this.ctx.bridge.send('setIconResource', {
+      widgetId: this.id,
+      iconName
+    });
+  }
+
+  /**
+   * Get the current icon name
+   */
+  getIconName(): ThemeIconName {
+    return this.iconName;
+  }
+}
+
+/**
+ * FileIcon widget - displays a file type icon
+ * Shows appropriate icons based on file type/extension with optional selection state
+ */
+export class FileIcon extends Widget {
+  constructor(ctx: Context, path: string) {
+    const id = ctx.generateId('fileicon');
+    super(ctx, id);
+
+    ctx.bridge.send('createFileIcon', { id, path });
+    ctx.addToCurrentContainer(id);
+  }
+
+  /**
+   * Set the file path for this icon
+   * @param path The path to the file (used to determine icon type)
+   */
+  async setURI(path: string): Promise<void> {
+    await this.ctx.bridge.send('setFileIconURI', {
+      widgetId: this.id,
+      path
+    });
+  }
+
+  /**
+   * Set the selection state of the file icon
+   * @param selected Whether the icon appears selected
+   */
+  async setSelected(selected: boolean): Promise<void> {
+    await this.ctx.bridge.send('setFileIconSelected', {
+      widgetId: this.id,
+      selected
+    });
+  }
+}
+
+/**
  * Label widget
  */
 export class Label extends Widget {

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -44,11 +44,15 @@ export {
   Slider,
   RadioGroup,
   CheckGroup,
-  DateEntry
+  DateEntry,
+  Calendar
 } from './inputs';
 
 // Display widgets
 export {
+  ThemeIconName,
+  Icon,
+  FileIcon,
   Label,
   Separator,
   Hyperlink,

--- a/src/widgets/inputs.ts
+++ b/src/widgets/inputs.ts
@@ -502,3 +502,35 @@ export class DateEntry extends Widget {
     });
   }
 }
+
+/**
+ * Calendar widget - Standalone calendar for date selection
+ * Displays a full calendar month view for selecting dates
+ * Unlike DateEntry, this shows the calendar inline without an input field
+ */
+export class Calendar extends Widget {
+  constructor(ctx: Context, initialDate?: string, onSelected?: (date: string) => void) {
+    const id = ctx.generateId('calendar');
+    super(ctx, id);
+
+    const payload: any = { id };
+
+    if (initialDate) {
+      payload.date = initialDate;
+    }
+
+    if (onSelected) {
+      const callbackId = ctx.generateId('callback');
+      payload.callbackId = callbackId;
+      ctx.bridge.registerEventHandler(callbackId, (data: any) => {
+        onSelected(data.date);
+      });
+    }
+
+    ctx.bridge.send('createCalendar', payload);
+    ctx.addToCurrentContainer(id);
+
+    // Apply styles from stylesheet (non-blocking)
+    this.applyStyles('calendar').catch(() => {});
+  }
+}


### PR DESCRIPTION
Implement three new Fyne widgets:
- Icon: Display theme icons that adapt to light/dark mode
- FileIcon: Show file type icons based on file extension
- Calendar: Standalone calendar for inline date selection

Includes Go bridge handlers, TypeScript classes, exports, and three example apps: icon-gallery, file-browser, and appointment-scheduler.