### PR TITLE
Add Fyne non-widget components to Tsyne

### DIFF
--- a/designer/public/editor.js
+++ b/designer/public/editor.js
@@ -226,6 +226,34 @@ const widgetPropertySchemas = {
   selectentry: {
     options: { type: 'string', description: 'Comma-separated options' },
     placeholder: { type: 'string', description: 'Placeholder text' }
+  },
+  // Canvas primitives
+  rectangle: {
+    color: { type: 'string', description: 'Fill color (hex or name)' },
+    width: { type: 'number', description: 'Width in pixels' },
+    height: { type: 'number', description: 'Height in pixels' }
+  },
+  circle: {
+    color: { type: 'string', description: 'Fill color (hex or name)' },
+    radius: { type: 'number', description: 'Radius in pixels' }
+  },
+  line: {
+    color: { type: 'string', description: 'Stroke color (hex or name)' },
+    strokeWidth: { type: 'number', description: 'Line thickness' }
+  },
+  linearGradient: {
+    startColor: { type: 'string', description: 'Starting color' },
+    endColor: { type: 'string', description: 'Ending color' },
+    angle: { type: 'number', description: 'Gradient angle in degrees' }
+  },
+  radialGradient: {
+    centerColor: { type: 'string', description: 'Center color' },
+    edgeColor: { type: 'string', description: 'Edge color' }
+  },
+  text: {
+    content: { type: 'string', description: 'Text content' },
+    size: { type: 'number', description: 'Font size' },
+    color: { type: 'string', description: 'Text color' }
   }
 };
 
@@ -894,7 +922,14 @@ function getWidgetIcon(type) {
     'table': '▦',
     'list': '☰',
     'tree': '⌲',
-    'activity': '◌'
+    'activity': '◌',
+    // Canvas primitives
+    'rectangle': '■',
+    'circle': '●',
+    'line': '╱',
+    'linearGradient': '▤',
+    'radialGradient': '◎',
+    'text': 'A'
   };
   return icons[type] || '○';
 }
@@ -1987,6 +2022,64 @@ function createPreviewWidget(widget) {
       element.style.background = 'transparent';
       element.style.border = 'none';
       element.innerHTML = `<div style="display: flex;"><input type="text" placeholder="${widget.properties?.placeholder || ''}" style="min-width: 100px; padding: 6px; background: #3c3c3c; border: 1px solid #5e5e5e; border-right: none; color: #d4d4d4; border-radius: 3px 0 0 3px;"><select style="padding: 6px; background: #3c3c3c; border: 1px solid #5e5e5e; color: #d4d4d4; border-radius: 0 3px 3px 0;"><option>▼</option></select></div>`;
+      break;
+
+    // Canvas primitives
+    case 'rectangle':
+      element.style.padding = '0';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const rectColor = widget.properties?.color || '#3c3c3c';
+      const rectWidth = widget.properties?.width ? `${widget.properties.width}px` : '60px';
+      const rectHeight = widget.properties?.height ? `${widget.properties.height}px` : '40px';
+      element.innerHTML = `<div style="width: ${rectWidth}; height: ${rectHeight}; background: ${rectColor}; border-radius: 2px;"></div>`;
+      break;
+
+    case 'circle':
+      element.style.padding = '0';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const circleColor = widget.properties?.color || '#3c3c3c';
+      const circleSize = widget.properties?.radius ? `${widget.properties.radius * 2}px` : '40px';
+      element.innerHTML = `<div style="width: ${circleSize}; height: ${circleSize}; background: ${circleColor}; border-radius: 50%;"></div>`;
+      break;
+
+    case 'line':
+      element.style.padding = '4px 0';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const lineColor = widget.properties?.color || '#5e5e5e';
+      const lineWidth = widget.properties?.strokeWidth || 2;
+      element.innerHTML = `<div style="height: ${lineWidth}px; background: ${lineColor}; width: 100%;"></div>`;
+      break;
+
+    case 'linearGradient':
+      element.style.padding = '0';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const lgStart = widget.properties?.startColor || '#0e639c';
+      const lgEnd = widget.properties?.endColor || '#3c3c3c';
+      const lgAngle = widget.properties?.angle || 0;
+      element.innerHTML = `<div style="width: 60px; height: 40px; background: linear-gradient(${lgAngle}deg, ${lgStart}, ${lgEnd}); border-radius: 2px;"></div>`;
+      break;
+
+    case 'radialGradient':
+      element.style.padding = '0';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const rgCenter = widget.properties?.centerColor || '#0e639c';
+      const rgEdge = widget.properties?.edgeColor || '#3c3c3c';
+      element.innerHTML = `<div style="width: 50px; height: 50px; background: radial-gradient(circle, ${rgCenter}, ${rgEdge}); border-radius: 2px;"></div>`;
+      break;
+
+    case 'text':
+      element.style.padding = '4px';
+      element.style.border = 'none';
+      element.style.background = 'transparent';
+      const textContent = widget.properties?.content || 'Text';
+      const textSize = widget.properties?.size ? `${widget.properties.size}px` : '14px';
+      const textColor = widget.properties?.color || '#d4d4d4';
+      element.innerHTML = `<span style="font-size: ${textSize}; color: ${textColor};">${escapeHtml(textContent)}</span>`;
       break;
 
     default:

--- a/designer/public/index.html
+++ b/designer/public/index.html
@@ -1027,6 +1027,15 @@
           <div class="palette-item" onclick="addWidget('list')"><span class="icon">☰</span>List</div>
           <div class="palette-item" onclick="addWidget('tree')"><span class="icon">⌲</span>Tree</div>
         </div>
+        <h3 style="margin-top: 15px;">Canvas</h3>
+        <div class="palette-grid">
+          <div class="palette-item" onclick="addWidget('rectangle')"><span class="icon">■</span>Rectangle</div>
+          <div class="palette-item" onclick="addWidget('circle')"><span class="icon">●</span>Circle</div>
+          <div class="palette-item" onclick="addWidget('line')"><span class="icon">╱</span>Line</div>
+          <div class="palette-item" onclick="addWidget('linearGradient')"><span class="icon">▤</span>LinGrad</div>
+          <div class="palette-item" onclick="addWidget('radialGradient')"><span class="icon">◎</span>RadGrad</div>
+          <div class="palette-item" onclick="addWidget('text')"><span class="icon">A</span>Text</div>
+        </div>
       </div>
       </div>
 

--- a/designer/src/server.ts
+++ b/designer/src/server.ts
@@ -1329,6 +1329,25 @@ class SourceCodeEditor {
       case 'grid':
         return `${indentation}a.grid(2, () => {\n${indentation}  // Add widgets here\n${indentation}});`;
 
+      // Canvas primitives
+      case 'rectangle':
+        return `${indentation}a.rectangle("${properties.color || '#3c3c3c'}"${properties.width ? `, ${properties.width}` : ''}${properties.height ? `, ${properties.height}` : ''});`;
+
+      case 'circle':
+        return `${indentation}a.circle("${properties.color || '#3c3c3c'}"${properties.radius ? `, ${properties.radius}` : ''});`;
+
+      case 'line':
+        return `${indentation}a.line("${properties.color || '#5e5e5e'}"${properties.strokeWidth ? `, ${properties.strokeWidth}` : ''});`;
+
+      case 'linearGradient':
+        return `${indentation}a.linearGradient("${properties.startColor || '#0e639c'}", "${properties.endColor || '#3c3c3c'}"${properties.angle !== undefined ? `, ${properties.angle}` : ''});`;
+
+      case 'radialGradient':
+        return `${indentation}a.radialGradient("${properties.centerColor || '#0e639c'}", "${properties.edgeColor || '#3c3c3c'}");`;
+
+      case 'text':
+        return `${indentation}a.text("${properties.content || 'Text'}"${properties.size ? `, ${properties.size}` : ''}${properties.color ? `, "${properties.color}"` : ''});`;
+
       default:
         return `${indentation}a.${widgetType}();`;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -370,6 +370,66 @@ export class App {
     return new CanvasRadialGradient(this.ctx, options);
   }
 
+  // Simple canvas primitive aliases for common use cases
+  /**
+   * Create a colored rectangle - simplified API for backgrounds, dividers, and placeholder boxes
+   * @param color Fill color (hex string like '#ff0000' or color name)
+   * @param width Optional width in pixels
+   * @param height Optional height in pixels
+   */
+  rectangle(color: string, width?: number, height?: number): CanvasRectangle {
+    return new CanvasRectangle(this.ctx, { fillColor: color, width, height });
+  }
+
+  /**
+   * Create a colored circle - simplified API for decorative elements
+   * @param color Fill color (hex string like '#ff0000' or color name)
+   * @param radius Optional radius - sets both x2 and y2 to create a circle of this size
+   */
+  circle(color: string, radius?: number): CanvasCircle {
+    const size = radius ? radius * 2 : undefined;
+    return new CanvasCircle(this.ctx, { fillColor: color, x2: size, y2: size });
+  }
+
+  /**
+   * Create a colored line - simplified API for dividers and decoration
+   * @param color Stroke color (hex string like '#ff0000' or color name)
+   * @param strokeWidth Optional line thickness
+   */
+  line(color: string, strokeWidth?: number): CanvasLine {
+    // Default to a horizontal line; position/size handled by container
+    return new CanvasLine(this.ctx, 0, 0, 100, 0, { strokeColor: color, strokeWidth });
+  }
+
+  /**
+   * Create a linear gradient background
+   * @param startColor Starting color of the gradient
+   * @param endColor Ending color of the gradient
+   * @param angle Optional angle in degrees (0 = horizontal left-to-right)
+   */
+  linearGradient(startColor: string, endColor: string, angle?: number): CanvasLinearGradient {
+    return new CanvasLinearGradient(this.ctx, { startColor, endColor, angle });
+  }
+
+  /**
+   * Create a radial gradient background
+   * @param centerColor Color at the center of the gradient
+   * @param edgeColor Color at the edges of the gradient
+   */
+  radialGradient(centerColor: string, edgeColor: string): CanvasRadialGradient {
+    return new CanvasRadialGradient(this.ctx, { startColor: centerColor, endColor: edgeColor });
+  }
+
+  /**
+   * Create canvas text - low-level text rendering (label is usually better for UI)
+   * @param content The text to display
+   * @param size Optional font size
+   * @param color Optional text color
+   */
+  text(content: string, size?: number, color?: string): CanvasText {
+    return new CanvasText(this.ctx, content, { textSize: size, color });
+  }
+
   clip(builder: () => void): Clip {
     return new Clip(this.ctx, builder);
   }


### PR DESCRIPTION
Add simplified factory methods for common canvas primitives:
- rectangle(color, width?, height?) - colored boxes/backgrounds
- circle(color, radius?) - decorative circles
- line(color, strokeWidth?) - custom dividers
- linearGradient(startColor, endColor, angle?) - gradient backgrounds
- radialGradient(centerColor, edgeColor) - radial gradients
- text(content, size?, color?) - low-level text rendering

These wrap the existing canvas* methods with simpler APIs for common use cases. Also adds support in the designer (palette, rendering, properties, and code generation).