### PR TITLE
Add tests and examples for recent commits

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -168,6 +168,7 @@ Individual examples showcasing specific widgets.
 | [**padded-demo.ts**](padded-demo.ts) | Padded container with spacing |
 | [**clip-demo.ts**](clip-demo.ts) | Clipped container demo |
 | [**card-stack.ts**](card-stack.ts) | Stacked card layout |
+| [**spacer-demo.ts**](spacer-demo.ts) | Spacer widget for flexible layout spacing |
 
 ### Input Widgets
 
@@ -191,6 +192,13 @@ Individual examples showcasing specific widgets.
 | [**loading-states.ts**](loading-states.ts) | Loading indicators and states |
 | [**icon-gallery.ts**](icon-gallery.ts) | Icon display and selection |
 | [**gradient-picker.ts**](gradient-picker.ts) | Gradient color picker |
+
+### Canvas Primitives
+
+| Example | Widgets Demonstrated |
+|---------|---------------------|
+| [**canvas-primitives.ts**](canvas-primitives.ts) | Simplified canvas APIs: rectangle(), circle(), line(), text(), gradients |
+| [**gradient-demo.ts**](gradient-demo.ts) | Linear and radial gradient comparison |
 
 ### Advanced Widgets
 

--- a/examples/canvas-primitives.test.ts
+++ b/examples/canvas-primitives.test.ts
@@ -1,0 +1,277 @@
+// Test for canvas-primitives example - tests simplified factory methods
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+describe('Canvas Primitives - Simple Factory Methods', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  describe('rectangle()', () => {
+    test('should create colored rectangle with simple API', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Rectangle Test' }, (win) => {
+          win.setContent(() => {
+            app.vbox(() => {
+              app.rectangle('#e74c3c', 100, 50);
+              app.rectangle('#3498db', 80, 40);
+            });
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      const rectangles = widgetInfo.filter((w: any) => w.type === 'canvasrectangle');
+      expect(rectangles.length).toBe(2);
+    });
+
+    test('should create rectangle with color only', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Rectangle Test' }, (win) => {
+          win.setContent(() => {
+            app.rectangle('#27ae60');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvasrectangle')).toBe(true);
+    });
+  });
+
+  describe('circle()', () => {
+    test('should create colored circle with radius', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Circle Test' }, (win) => {
+          win.setContent(() => {
+            app.vbox(() => {
+              app.circle('#e74c3c', 30);
+              app.circle('#3498db', 25);
+            });
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      const circles = widgetInfo.filter((w: any) => w.type === 'canvascircle');
+      expect(circles.length).toBe(2);
+    });
+
+    test('should create circle with color only', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Circle Test' }, (win) => {
+          win.setContent(() => {
+            app.circle('#f1c40f');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvascircle')).toBe(true);
+    });
+  });
+
+  describe('line()', () => {
+    test('should create colored line with stroke width', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Line Test' }, (win) => {
+          win.setContent(() => {
+            app.vbox(() => {
+              app.line('#e74c3c', 2);
+              app.line('#3498db', 5);
+            });
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      const lines = widgetInfo.filter((w: any) => w.type === 'canvasline');
+      expect(lines.length).toBe(2);
+    });
+
+    test('should create line with color only', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Line Test' }, (win) => {
+          win.setContent(() => {
+            app.line('#27ae60');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvasline')).toBe(true);
+    });
+  });
+
+  describe('linearGradient()', () => {
+    test('should create linear gradient with two colors', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Gradient Test' }, (win) => {
+          win.setContent(() => {
+            app.linearGradient('#e74c3c', '#3498db');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvaslineargradient')).toBe(true);
+    });
+
+    test('should create linear gradient with angle', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Gradient Test' }, (win) => {
+          win.setContent(() => {
+            app.linearGradient('#f1c40f', '#9b59b6', 45);
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvaslineargradient')).toBe(true);
+    });
+  });
+
+  describe('radialGradient()', () => {
+    test('should create radial gradient', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Radial Gradient Test' }, (win) => {
+          win.setContent(() => {
+            app.radialGradient('#ffffff', '#e74c3c');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvasradialgradient')).toBe(true);
+    });
+  });
+
+  describe('text()', () => {
+    test('should create canvas text with content', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Text Test' }, (win) => {
+          win.setContent(() => {
+            app.text('Hello Canvas');
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvastext')).toBe(true);
+    });
+
+    test('should create canvas text with size and color', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Text Test' }, (win) => {
+          win.setContent(() => {
+            app.vbox(() => {
+              app.text('Large Text', 24);
+              app.text('Colored Text', 16, '#e74c3c');
+            });
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      const widgetInfo = await ctx.getAllWidgets();
+      const textWidgets = widgetInfo.filter((w: any) => w.type === 'canvastext');
+      expect(textWidgets.length).toBe(2);
+    });
+  });
+
+  describe('Full demo', () => {
+    test('should create all canvas primitives with simple APIs', async () => {
+      const testApp = await tsyneTest.createApp((app) => {
+        app.window({ title: 'Canvas Primitives', width: 600, height: 500 }, (win) => {
+          win.setContent(() => {
+            app.vbox(() => {
+              app.label('Canvas Primitives Demo');
+              app.hbox(() => {
+                app.rectangle('#e74c3c', 80, 60);
+                app.circle('#3498db', 30);
+                app.line('#27ae60', 3);
+              });
+              app.hbox(() => {
+                app.linearGradient('#e74c3c', '#3498db');
+                app.radialGradient('#ffffff', '#9b59b6');
+              });
+              app.text('Canvas Text', 20, '#333333');
+            });
+          });
+          win.show();
+        });
+      });
+
+      ctx = tsyneTest.getContext();
+      await testApp.run();
+
+      // Verify all primitive types are created
+      const widgetInfo = await ctx.getAllWidgets();
+      expect(widgetInfo.some((w: any) => w.type === 'canvasrectangle')).toBe(true);
+      expect(widgetInfo.some((w: any) => w.type === 'canvascircle')).toBe(true);
+      expect(widgetInfo.some((w: any) => w.type === 'canvasline')).toBe(true);
+      expect(widgetInfo.some((w: any) => w.type === 'canvaslineargradient')).toBe(true);
+      expect(widgetInfo.some((w: any) => w.type === 'canvasradialgradient')).toBe(true);
+      expect(widgetInfo.some((w: any) => w.type === 'canvastext')).toBe(true);
+
+      // Capture screenshot if TAKE_SCREENSHOTS=1
+      if (process.env.TAKE_SCREENSHOTS === '1') {
+        const screenshotPath = path.join(__dirname, 'screenshots', 'canvas-primitives.png');
+        await ctx.wait(500);
+        await tsyneTest.screenshot(screenshotPath);
+        console.log(`Screenshot saved: ${screenshotPath}`);
+      }
+    });
+  });
+});

--- a/examples/canvas-primitives.ts
+++ b/examples/canvas-primitives.ts
@@ -1,0 +1,113 @@
+// Demo: Simplified Canvas Primitive Factory Methods
+// Shows the new simple APIs: rectangle(), circle(), line(), linearGradient(), radialGradient(), text()
+
+import { app } from '../src';
+
+app({ title: 'Canvas Primitives' }, (a) => {
+  a.window({ title: 'Canvas Primitives - Simple APIs', width: 600, height: 500 }, (win) => {
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Simplified Canvas Primitive Factory Methods');
+        a.separator();
+
+        // Rectangles section
+        a.label('Rectangles - a.rectangle(color, width?, height?)');
+        a.hbox(() => {
+          a.vbox(() => {
+            a.label('Basic');
+            a.rectangle('#e74c3c', 80, 60);
+          });
+          a.vbox(() => {
+            a.label('Blue');
+            a.rectangle('#3498db', 80, 60);
+          });
+          a.vbox(() => {
+            a.label('Green');
+            a.rectangle('#27ae60', 80, 60);
+          });
+          a.vbox(() => {
+            a.label('Purple');
+            a.rectangle('#9b59b6', 80, 60);
+          });
+        });
+
+        a.separator();
+
+        // Circles section
+        a.label('Circles - a.circle(color, radius?)');
+        a.hbox(() => {
+          a.vbox(() => {
+            a.label('Red r=30');
+            a.circle('#e74c3c', 30);
+          });
+          a.vbox(() => {
+            a.label('Blue r=25');
+            a.circle('#3498db', 25);
+          });
+          a.vbox(() => {
+            a.label('Yellow r=35');
+            a.circle('#f1c40f', 35);
+          });
+          a.vbox(() => {
+            a.label('Orange r=20');
+            a.circle('#e67e22', 20);
+          });
+        });
+
+        a.separator();
+
+        // Lines section
+        a.label('Lines - a.line(color, strokeWidth?)');
+        a.hbox(() => {
+          a.vbox(() => {
+            a.label('Thin red');
+            a.line('#e74c3c', 1);
+          });
+          a.vbox(() => {
+            a.label('Medium blue');
+            a.line('#3498db', 3);
+          });
+          a.vbox(() => {
+            a.label('Thick green');
+            a.line('#27ae60', 5);
+          });
+        });
+
+        a.separator();
+
+        // Gradients section
+        a.label('Gradients - linearGradient() & radialGradient()');
+        a.hbox(() => {
+          a.vbox(() => {
+            a.label('Linear');
+            a.linearGradient('#e74c3c', '#3498db');
+          });
+          a.vbox(() => {
+            a.label('Linear 45deg');
+            a.linearGradient('#f1c40f', '#9b59b6', 45);
+          });
+          a.vbox(() => {
+            a.label('Radial');
+            a.radialGradient('#ffffff', '#e74c3c');
+          });
+          a.vbox(() => {
+            a.label('Radial Blue');
+            a.radialGradient('#ffffff', '#3498db');
+          });
+        });
+
+        a.separator();
+
+        // Text section
+        a.label('Text - a.text(content, size?, color?)');
+        a.hbox(() => {
+          a.text('Default', undefined, undefined);
+          a.text('Large', 24, undefined);
+          a.text('Red', 16, '#e74c3c');
+          a.text('Blue 20px', 20, '#3498db');
+        });
+      });
+    });
+    win.show();
+  });
+});

--- a/examples/spacer-demo.test.ts
+++ b/examples/spacer-demo.test.ts
@@ -1,0 +1,100 @@
+// Test for spacer-demo example
+import { TsyneTest, TestContext } from '../src/index-test';
+import * as path from 'path';
+
+describe('Spacer Demo Example', () => {
+  let tsyneTest: TsyneTest;
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    const headed = process.env.TSYNE_HEADED === '1';
+    tsyneTest = new TsyneTest({ headed });
+  });
+
+  afterEach(async () => {
+    await tsyneTest.cleanup();
+  });
+
+  test('should create spacer widgets for flexible layout', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Spacer Layout Demo', width: 400, height: 300 }, (win) => {
+        win.setContent(() => {
+          app.vbox(() => {
+            app.label('Spacer Demo - Flexible Layout Spacing');
+            app.separator();
+
+            // Horizontal layout with spacers
+            app.label('Horizontal spacers (buttons pushed to edges):');
+            app.hbox(() => {
+              app.button('Left', () => {});
+              app.spacer();
+              app.button('Right', () => {});
+            });
+
+            app.separator();
+
+            // Multiple spacers for even distribution
+            app.label('Multiple spacers (evenly distributed):');
+            app.hbox(() => {
+              app.spacer();
+              app.button('A', () => {});
+              app.spacer();
+              app.button('B', () => {});
+              app.spacer();
+              app.button('C', () => {});
+              app.spacer();
+            });
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify spacer widgets were created
+    const widgetInfo = await ctx.getAllWidgets();
+    const spacers = widgetInfo.filter((w: any) => w.type === 'spacer');
+    expect(spacers.length).toBeGreaterThanOrEqual(5); // At least 5 spacers
+
+    // Verify labels and buttons are visible
+    await ctx.expect(ctx.getByExactText('Spacer Demo - Flexible Layout Spacing')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Left')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('Right')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('A')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('B')).toBeVisible();
+    await ctx.expect(ctx.getByExactText('C')).toBeVisible();
+
+    // Capture screenshot if TAKE_SCREENSHOTS=1
+    if (process.env.TAKE_SCREENSHOTS === '1') {
+      const screenshotPath = path.join(__dirname, 'screenshots', 'spacer-demo.png');
+      await ctx.wait(500);
+      await tsyneTest.screenshot(screenshotPath);
+      console.log(`Screenshot saved: ${screenshotPath}`);
+    }
+  });
+
+  test('should verify spacer widget metadata', async () => {
+    const testApp = await tsyneTest.createApp((app) => {
+      app.window({ title: 'Spacer Test', width: 200, height: 100 }, (win) => {
+        win.setContent(() => {
+          app.hbox(() => {
+            app.button('A', () => {});
+            app.spacer();
+            app.button('B', () => {});
+          });
+        });
+        win.show();
+      });
+    });
+
+    ctx = tsyneTest.getContext();
+    await testApp.run();
+
+    // Verify spacer is correctly identified
+    const widgetInfo = await ctx.getAllWidgets();
+    const spacers = widgetInfo.filter((w: any) => w.type === 'spacer');
+    expect(spacers.length).toBe(1);
+  });
+});

--- a/examples/spacer-demo.ts
+++ b/examples/spacer-demo.ts
@@ -1,0 +1,59 @@
+// Demo: Spacer widget for flexible spacing in layouts
+// Demonstrates the use of layout.NewSpacer() via a.spacer()
+
+import { app } from '../src';
+
+app({ title: 'Spacer Demo' }, (a) => {
+  a.window({ title: 'Spacer Layout Demo', width: 400, height: 300 }, (win) => {
+    win.setContent(() => {
+      a.vbox(() => {
+        a.label('Spacer Demo - Flexible Layout Spacing');
+        a.separator();
+
+        // Horizontal layout with spacers
+        a.label('Horizontal spacers (buttons pushed to edges):');
+        a.hbox(() => {
+          a.button('Left', () => {});
+          a.spacer(); // Pushes content to edges
+          a.button('Right', () => {});
+        });
+
+        a.separator();
+
+        // Multiple spacers for even distribution
+        a.label('Multiple spacers (evenly distributed):');
+        a.hbox(() => {
+          a.spacer();
+          a.button('A', () => {});
+          a.spacer();
+          a.button('B', () => {});
+          a.spacer();
+          a.button('C', () => {});
+          a.spacer();
+        });
+
+        a.separator();
+
+        // Vertical spacer example
+        a.label('Vertical spacer pushes content down:');
+        a.vbox(() => {
+          a.label('Top content');
+          a.spacer(); // Fills vertical space
+          a.label('Bottom content');
+        });
+
+        a.separator();
+
+        // Toolbar-style layout
+        a.label('Toolbar style (actions right-aligned):');
+        a.hbox(() => {
+          a.label('File: document.txt');
+          a.spacer();
+          a.button('Save', () => {});
+          a.button('Cancel', () => {});
+        });
+      });
+    });
+    win.show();
+  });
+});


### PR DESCRIPTION
- Add spacer-demo.ts: Example demonstrating a.spacer() for flexible layout spacing
- Add spacer-demo.test.ts: Tests for spacer widget functionality
- Add canvas-primitives.ts: Example showing simplified canvas factory methods (rectangle(), circle(), line(), linearGradient(), radialGradient(), text())
- Add canvas-primitives.test.ts: Comprehensive tests for all simple canvas APIs
- Update examples/README.md: Document new examples in Layout Containers and new Canvas Primitives section

These examples provide coverage for features added in recent commits:
- a7c5b11: spacer/separator addition
- a28d728: Add simple canvas primitive factory methods