### PR TITLE
Reduce noise in test output logs

### DIFF
--- a/examples/todomvc-when.ts
+++ b/examples/todomvc-when.ts
@@ -108,9 +108,8 @@ class TodoStore {
         const parsed = JSON.parse(data);
         this.todos = parsed.todos || [];
         this.nextId = parsed.nextId || 1;
-        console.log(`Loaded ${this.todos.length} todos from ${this.filePath}`);
       } else {
-        console.log(`No existing file at ${this.filePath}, starting fresh`);
+        // Starting fresh - no existing file
       }
     } catch (error) {
       console.error(`Error loading todos: ${error}`);
@@ -127,7 +126,6 @@ class TodoStore {
         nextId: this.nextId
       }, null, 2);
       fs.writeFileSync(this.filePath, data, 'utf8');
-      console.log(`Saved ${this.todos.length} todos to ${this.filePath}`);
     } catch (error) {
       console.error(`Error saving todos: ${error}`);
     }


### PR DESCRIPTION
Remove console.log statements from TodoStore that were cluttering test output during automated testing. Keep console.error for actual error conditions.