### PR TITLE
Replace wait calls with assertion helpers in tests

### DIFF
--- a/examples/tictactoe-accessible.test.ts
+++ b/examples/tictactoe-accessible.test.ts
@@ -36,15 +36,16 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready - poll for first control
+    await ctx.getByText('TTS: OFF').within(500).shouldExist();
 
     // Verify accessibility controls are present
-    await ctx.expect(ctx.getByText('TTS: OFF')).toBeVisible();
-    await ctx.expect(ctx.getByText('High Contrast: OFF')).toBeVisible();
-    await ctx.expect(ctx.getByText('Font: A')).toBeVisible();
-    await ctx.expect(ctx.getByText('New Game')).toBeVisible();
-    await ctx.expect(ctx.getByText('Undo')).toBeVisible();
-    await ctx.expect(ctx.getByText('Hint')).toBeVisible();
+    await ctx.getByText('High Contrast: OFF').shouldExist();
+    await ctx.getByText('Font: A').shouldExist();
+    await ctx.getByText('New Game').shouldExist();
+    await ctx.getByText('Undo').shouldExist();
+    await ctx.getByText('Hint').shouldExist();
   });
 
   test.skip('should toggle TTS on and off', async () => {
@@ -54,21 +55,21 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText('TTS: OFF').within(500).shouldExist();
 
     // Toggle TTS ON
     await ctx.getByText('TTS: OFF').click();
-    await ctx.wait(300);
 
-    // Verify TTS is ON
-    await ctx.expect(ctx.getByText('TTS: ON')).toBeVisible();
+    // Verify TTS is ON - poll for state change
+    await ctx.getByText('TTS: ON').within(300).shouldExist();
 
     // Toggle TTS OFF
     await ctx.getByText('TTS: ON').click();
-    await ctx.wait(300);
 
-    // Verify TTS is OFF
-    await ctx.expect(ctx.getByText('TTS: OFF')).toBeVisible();
+    // Verify TTS is OFF - poll for state change
+    await ctx.getByText('TTS: OFF').within(300).shouldExist();
   });
 
   test('should cycle font sizes', async () => {
@@ -78,25 +79,21 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
 
-    // Initial state
-    await ctx.expect(ctx.getByText('Font: A')).toBeVisible();
+    // Initial state - poll for UI readiness
+    await ctx.getByText('Font: A').within(500).shouldExist();
 
     // Cycle to Large
     await ctx.getByText('Font: A').click();
-    await ctx.wait(300);
-    await ctx.expect(ctx.getByText('Font: A+')).toBeVisible();
+    await ctx.getByText('Font: A+').within(300).shouldExist();
 
     // Cycle to Small
     await ctx.getByText('Font: A+').click();
-    await ctx.wait(300);
-    await ctx.expect(ctx.getByText('Font: A-')).toBeVisible();
+    await ctx.getByText('Font: A-').within(300).shouldExist();
 
     // Cycle back to Medium
     await ctx.getByText('Font: A-').click();
-    await ctx.wait(300);
-    await ctx.expect(ctx.getByText('Font: A')).toBeVisible();
+    await ctx.getByText('Font: A').within(300).shouldExist();
   });
 
   test('should display move history', async () => {
@@ -106,23 +103,20 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
 
-    // Initial state - no moves yet
-    await ctx.expect(ctx.getByText('No moves yet')).toBeVisible();
+    // Initial state - no moves yet (poll for UI readiness)
+    await ctx.getByText('No moves yet').within(500).shouldExist();
 
     // Make some moves
     await ctx.getByID('cell4').click(); // X center
-    await ctx.wait(300);
 
-    // History should update
-    await ctx.expect(ctx.getByText('X at center')).toBeVisible();
+    // History should update - poll for state change
+    await ctx.getByText('X at center').within(300).shouldExist();
 
     await ctx.getByID('cell0').click(); // O top-left
-    await ctx.wait(300);
 
-    // Both moves in history
-    await ctx.expect(ctx.getByText('O at top left')).toBeVisible();
+    // Both moves in history - poll for state change
+    await ctx.getByText('O at top left').within(300).shouldExist();
   });
 
   test.skip('should support undo functionality', async () => {
@@ -132,21 +126,21 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Make a move
     await ctx.getByID('cell4').click();
-    await ctx.wait(300);
 
-    // Should be O's turn
-    await ctx.expect(ctx.getByText("Player O's turn")).toBeVisible();
+    // Should be O's turn - poll for state change
+    await ctx.getByText("Player O's turn").within(300).shouldExist();
 
     // Undo the move
     await ctx.getByText('Undo').click();
-    await ctx.wait(300);
 
-    // Should be back to X's turn
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
+    // Should be back to X's turn - poll for undo
+    await ctx.getByText("Player X's turn").within(300).shouldExist();
   });
 
   test('should provide hints', async () => {
@@ -156,15 +150,16 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText('Hint').within(500).shouldExist();
 
     // Click hint button
     await ctx.getByText('Hint').click();
-    await ctx.wait(300);
 
     // Hint should suggest center (traditionally best first move)
-    // The hint system suggests moves, we just verify the button works
-    await ctx.expect(ctx.getByText('Hint')).toBeVisible();
+    // The hint system suggests moves, we just verify the button still works
+    await ctx.getByText('Hint').within(300).shouldExist();
   });
 
   test.skip('should play full game with all features', async () => {
@@ -174,39 +169,39 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText('TTS: OFF').within(500).shouldExist();
 
     // Enable TTS
     await ctx.getByText('TTS: OFF').click();
-    await ctx.wait(200);
+    await ctx.getByText('TTS: ON').within(200).shouldExist();
 
     // Enable high contrast
     await ctx.getByText('High Contrast: OFF').click();
-    await ctx.wait(500);
+    await ctx.getByText('High Contrast: ON').within(500).shouldExist();
 
     // Play a winning game
     const moves = [0, 3, 1, 4, 2]; // X wins top row
     for (const moveIdx of moves) {
-      await ctx.getByID(`cell${moveIdx}`).click();
-      await ctx.wait(300);
+      await ctx.getByID(`cell${moveIdx}`).within(300).click();
     }
 
-    // Verify win
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Verify win - poll for win message
+    await ctx.getByText('Player X wins!').within(300).shouldExist();
 
     // Verify history shows all moves
-    await ctx.expect(ctx.getByText('X at top left')).toBeVisible();
+    await ctx.getByText('X at top left').shouldExist();
 
     // Start new game
     await ctx.getByText('New Game').click();
-    await ctx.wait(300);
 
-    // Verify reset
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
-    await ctx.expect(ctx.getByText('No moves yet')).toBeVisible();
+    // Verify reset - poll for state changes
+    await ctx.getByText("Player X's turn").within(300).shouldExist();
+    await ctx.getByText('No moves yet').shouldExist();
 
     // High contrast should still be ON after new game
-    await ctx.expect(ctx.getByText('High Contrast: ON')).toBeVisible();
+    await ctx.getByText('High Contrast: ON').shouldExist();
   });
 
   test('should handle rapid moves gracefully', async () => {
@@ -216,16 +211,17 @@ describe('Accessible Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
 
-    // Rapid moves
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
+
+    // Rapid moves with short polling
     for (let i = 0; i < 5; i++) {
-      await ctx.getByID(`cell${i}`).click();
-      await ctx.wait(100); // Short delay
+      await ctx.getByID(`cell${i}`).within(100).click();
     }
 
-    // Game should still be functional
-    await ctx.expect(ctx.getByText('New Game')).toBeVisible();
+    // Game should still be functional - poll for UI state
+    await ctx.getByText('New Game').within(100).shouldExist();
   });
 
   // Screenshot tests
@@ -237,22 +233,25 @@ describe('Accessible Tic-Tac-Toe', () => {
 
       ctx = tsyneTest.getContext();
       await testApp.run();
-      await ctx.wait(500);
+
+      // Wait for UI to be ready
+      await ctx.getByText('High Contrast: OFF').within(500).shouldExist();
 
       // Enable high contrast
       await ctx.getByText('High Contrast: OFF').click();
-      await ctx.wait(500);
+      await ctx.getByText('High Contrast: ON').within(500).shouldExist();
 
       // Make some moves
       await ctx.getByID('cell4').click();
-      await ctx.wait(200);
+      await ctx.getByText("Player O's turn").within(200).shouldExist();
+
       await ctx.getByID('cell0').click();
-      await ctx.wait(200);
+      await ctx.getByText("Player X's turn").within(200).shouldExist();
+
       await ctx.getByID('cell2').click();
-      await ctx.wait(200);
+      await ctx.getByText("Player O's turn").within(200).shouldExist();
 
       const screenshotPath = path.join(__dirname, 'screenshots', 'tictactoe-accessible-full.png');
-      await ctx.wait(500);
       await tsyneTest.screenshot(screenshotPath);
       console.log(`📸 Screenshot saved: ${screenshotPath}`);
     });

--- a/examples/tictactoe-high-contrast.test.ts
+++ b/examples/tictactoe-high-contrast.test.ts
@@ -34,60 +34,54 @@ describe('Tictactoe High Contrast Mode', () => {
     ctx = tsyneTest.getContext();
     await testApp.run();
 
-    // Wait for UI to render
-    await ctx.wait(500);
+    // Wait for UI to render - poll for initial state
+    await ctx.getByText('High Contrast: OFF').within(500).shouldExist();
 
     // Make some moves to populate the board for better visual testing
     // X in center (cell4)
     await ctx.getByID('cell4').click();
-    await ctx.wait(200);
+    await ctx.getByText("Player O's turn").within(200).shouldExist();
 
     // O in top-left (cell0)
     await ctx.getByID('cell0').click();
-    await ctx.wait(200);
+    await ctx.getByText("Player X's turn").within(200).shouldExist();
 
     // X in top-right (cell2)
     await ctx.getByID('cell2').click();
-    await ctx.wait(200);
+    await ctx.getByText("Player O's turn").within(200).shouldExist();
 
     // O in bottom-left (cell6)
     await ctx.getByID('cell6').click();
-    await ctx.wait(200);
+    await ctx.getByText("Player X's turn").within(200).shouldExist();
 
     // Verify initial state
-    await ctx.expect(ctx.getByText('High Contrast: OFF')).toBeVisible();
+    await ctx.getByText('High Contrast: OFF').shouldExist();
 
     // Capture screenshot in normal mode if requested
     if (process.env.TAKE_SCREENSHOTS === '1') {
       const screenshotPath = path.join(__dirname, 'screenshots', 'tictactoe-normal-mode.png');
-      await ctx.wait(500);
       await tsyneTest.screenshot(screenshotPath);
       console.log(`📸 Normal mode screenshot: ${screenshotPath}`);
     }
 
     // Toggle high contrast ON
-    const contrastButton = ctx.getByText('High Contrast: OFF');
-    await contrastButton.click();
-    await ctx.wait(500);
+    await ctx.getByText('High Contrast: OFF').click();
 
-    // Verify high contrast is ON
-    await ctx.expect(ctx.getByText('High Contrast: ON')).toBeVisible();
+    // Verify high contrast is ON - poll for state change
+    await ctx.getByText('High Contrast: ON').within(500).shouldExist();
 
     // Capture screenshot in high contrast mode if requested
     if (process.env.TAKE_SCREENSHOTS === '1') {
       const screenshotPath = path.join(__dirname, 'screenshots', 'tictactoe-high-contrast-mode.png');
-      await ctx.wait(500);
       await tsyneTest.screenshot(screenshotPath);
       console.log(`📸 High contrast mode screenshot: ${screenshotPath}`);
     }
 
     // Toggle high contrast OFF
-    const contrastButtonOn = ctx.getByText('High Contrast: ON');
-    await contrastButtonOn.click();
-    await ctx.wait(500);
+    await ctx.getByText('High Contrast: ON').click();
 
-    // Verify high contrast is OFF again
-    await ctx.expect(ctx.getByText('High Contrast: OFF')).toBeVisible();
+    // Verify high contrast is OFF again - poll for state change
+    await ctx.getByText('High Contrast: OFF').within(500).shouldExist();
 
     // Keep window visible for a moment in headed mode
     if (process.env.TSYNE_HEADED === '1') {
@@ -103,35 +97,34 @@ describe('Tictactoe High Contrast Mode', () => {
     ctx = tsyneTest.getContext();
     await testApp.run();
 
-    await ctx.wait(500);
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Make a move
     await ctx.getByID('cell4').click();
-    await ctx.wait(500);
+    await ctx.getByText("Player O's turn").within(500).shouldExist();
 
     // Toggle high contrast ON
     await ctx.getByText('High Contrast: OFF').click();
-    await ctx.wait(500);
 
-    // Verify high contrast is ON
-    await ctx.expect(ctx.getByText('High Contrast: ON')).toBeVisible();
+    // Verify high contrast is ON - poll for state change
+    await ctx.getByText('High Contrast: ON').within(500).shouldExist();
 
     // Make another move to verify game still works
     await ctx.getByID('cell0').click();
-    await ctx.wait(500);
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Toggle high contrast OFF
     await ctx.getByText('High Contrast: ON').click();
-    await ctx.wait(500);
 
-    // Verify high contrast is OFF
-    await ctx.expect(ctx.getByText('High Contrast: OFF')).toBeVisible();
+    // Verify high contrast is OFF - poll for state change
+    await ctx.getByText('High Contrast: OFF').within(500).shouldExist();
 
     // Make one more move to verify game still works
     await ctx.getByID('cell2').click();
-    await ctx.wait(500);
+    await ctx.getByText("Player O's turn").within(500).shouldExist();
 
     // Game should still be functional - verify New Game button exists
-    await ctx.expect(ctx.getByText('New Game')).toBeVisible();
+    await ctx.getByText('New Game').shouldExist();
   });
 });

--- a/examples/tictactoe-mespeak.test.ts
+++ b/examples/tictactoe-mespeak.test.ts
@@ -27,25 +27,25 @@ describe('meSpeak TTS Integration', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText('TTS: OFF').within(500).shouldExist();
 
     // Enable TTS mode
     await ctx.getByText('TTS: OFF').click();
-    await ctx.wait(500);
+    await ctx.getByText('TTS: ON').within(500).shouldExist();
 
     // Make some moves - TTS should announce them
     await ctx.getByID('cell0').click();  // X in top left
-    await ctx.wait(300);
+    await ctx.getByText("Player O's turn").within(300).shouldExist();
 
     await ctx.getByID('cell1').click();  // O in top center
-    await ctx.wait(300);
+    await ctx.getByText("Player X's turn").within(300).shouldExist();
 
     await ctx.getByID('cell3').click();  // X in middle left
-    await ctx.wait(300);
-
     // If we got here without errors, meSpeak is working
     // The app is still running and responsive
-    await ctx.expect(ctx.getByText("Player O's turn")).toBeVisible();
+    await ctx.getByText("Player O's turn").within(300).shouldExist();
   }, 30000);
 
   test('should announce multiple moves without errors', async () => {
@@ -55,26 +55,26 @@ describe('meSpeak TTS Integration', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText('TTS: OFF').within(500).shouldExist();
 
     // Enable TTS
     await ctx.getByText('TTS: OFF').click();
-    await ctx.wait(500);
+    await ctx.getByText('TTS: ON').within(500).shouldExist();
 
     // Make multiple moves - each should be announced
     await ctx.getByID('cell4').click();  // X in center
-    await ctx.wait(300);
+    await ctx.getByText("Player O's turn").within(300).shouldExist();
 
     await ctx.getByID('cell0').click();  // O in top left
-    await ctx.wait(300);
+    await ctx.getByText("Player X's turn").within(300).shouldExist();
 
     await ctx.getByID('cell8').click();  // X in bottom right
-    await ctx.wait(300);
+    await ctx.getByText("Player O's turn").within(300).shouldExist();
 
     await ctx.getByID('cell2').click();  // O in top right
-    await ctx.wait(300);
-
     // Verify game is still working after multiple TTS announcements
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
+    await ctx.getByText("Player X's turn").within(300).shouldExist();
   }, 30000);
 });

--- a/examples/tictactoe.test.ts
+++ b/examples/tictactoe.test.ts
@@ -30,11 +30,9 @@ describe('Basic Tic-Tac-Toe', () => {
     ctx = tsyneTest.getContext();
     await testApp.run();
 
-    await ctx.wait(500);
-
-    // Verify initial state
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
-    await ctx.expect(ctx.getByText('New Game')).toBeVisible();
+    // Verify initial state - use within() to poll for UI readiness
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
+    await ctx.getByText('New Game').shouldExist();
   });
 
   test('should allow placing X and O alternately', async () => {
@@ -44,21 +42,21 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // X's turn - click center
     await ctx.getByID('cell4').click();
-    await ctx.wait(200);
 
-    // Should now be O's turn
-    await ctx.expect(ctx.getByText("Player O's turn")).toBeVisible();
+    // Should now be O's turn - poll for state change
+    await ctx.getByText("Player O's turn").within(200).shouldExist();
 
     // O's turn - click top-left
     await ctx.getByID('cell0').click();
-    await ctx.wait(200);
 
-    // Should be X's turn again
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
+    // Should be X's turn again - poll for state change
+    await ctx.getByText("Player X's turn").within(200).shouldExist();
   });
 
   test('should detect horizontal win', async () => {
@@ -68,18 +66,19 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Create top row win for X: X X X / O O _ / _ _ _
     const moves = [0, 3, 1, 4, 2]; // X wins top row
 
     for (const move of moves) {
-      await ctx.getByID(`cell${move}`).click();
-      await ctx.wait(200);
+      await ctx.getByID(`cell${move}`).within(200).click();
     }
 
-    // Verify X wins
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Verify X wins - poll for win message
+    await ctx.getByText('Player X wins!').within(200).shouldExist();
   });
 
   test('should detect vertical win', async () => {
@@ -89,7 +88,9 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Create left column win for X
     const moves = [
@@ -101,12 +102,11 @@ describe('Basic Tic-Tac-Toe', () => {
     ];
 
     for (const move of moves) {
-      // Using cell IDs instead
-      await ctx.getByID(`cell${move}`).click();
-      await ctx.wait(200);
+      await ctx.getByID(`cell${move}`).within(200).click();
     }
 
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Verify X wins - poll for win message
+    await ctx.getByText('Player X wins!').within(200).shouldExist();
   });
 
   test('should detect diagonal win', async () => {
@@ -116,7 +116,9 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Create diagonal win for X (top-left to bottom-right)
     const moves = [
@@ -128,12 +130,11 @@ describe('Basic Tic-Tac-Toe', () => {
     ];
 
     for (const move of moves) {
-      // Using cell IDs instead
-      await ctx.getByID(`cell${move}`).click();
-      await ctx.wait(200);
+      await ctx.getByID(`cell${move}`).within(200).click();
     }
 
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Verify X wins - poll for win message
+    await ctx.getByText('Player X wins!').within(200).shouldExist();
   });
 
   test('should detect draw', async () => {
@@ -143,18 +144,19 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Create a draw: X X O / O O X / X O X
     const moves = [0, 2, 1, 3, 5, 4, 6, 8, 7];
 
     for (const move of moves) {
-      // Using cell IDs instead
-      await ctx.getByID(`cell${move}`).click();
-      await ctx.wait(200);
+      await ctx.getByID(`cell${move}`).within(200).click();
     }
 
-    await ctx.expect(ctx.getByText("It's a draw!")).toBeVisible();
+    // Verify draw - poll for draw message
+    await ctx.getByText("It's a draw!").within(200).shouldExist();
   });
 
   test('should reset game with New Game button', async () => {
@@ -164,21 +166,21 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Make a move
     await ctx.getByID('cell4').click();
-    await ctx.wait(200);
 
-    // Should be O's turn
-    await ctx.expect(ctx.getByText("Player O's turn")).toBeVisible();
+    // Should be O's turn - poll for state change
+    await ctx.getByText("Player O's turn").within(200).shouldExist();
 
     // Click New Game
     await ctx.getByText('New Game').click();
-    await ctx.wait(200);
 
-    // Should be back to X's turn
-    await ctx.expect(ctx.getByText("Player X's turn")).toBeVisible();
+    // Should be back to X's turn - poll for reset
+    await ctx.getByText("Player X's turn").within(200).shouldExist();
   });
 
   test('should not allow moves after game ends', async () => {
@@ -188,27 +190,22 @@ describe('Basic Tic-Tac-Toe', () => {
 
     ctx = tsyneTest.getContext();
     await testApp.run();
-    await ctx.wait(500);
+
+    // Wait for UI to be ready
+    await ctx.getByText("Player X's turn").within(500).shouldExist();
 
     // Quick win
     const moves = [0, 3, 1, 4, 2]; // X wins top row
 
     for (const move of moves) {
-      // Using cell IDs instead
-      await ctx.getByID(`cell${move}`).click();
-      await ctx.wait(200);
+      await ctx.getByID(`cell${move}`).within(200).click();
     }
 
-    // Game should be over
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Game should be over - poll for win message
+    await ctx.getByText('Player X wins!').within(200).shouldExist();
 
-    // Try to make another move (should not work)
-    // Using cell IDs instead
-    // Cell already filled;
-    await ctx.wait(200);
-
-    // Should still show X wins
-    await ctx.expect(ctx.getByText('Player X wins!')).toBeVisible();
+    // Should still show X wins (game state preserved)
+    await ctx.getByText('Player X wins!').shouldExist();
   });
 
   // Screenshot test
@@ -220,18 +217,20 @@ describe('Basic Tic-Tac-Toe', () => {
 
       ctx = tsyneTest.getContext();
       await testApp.run();
-      await ctx.wait(500);
+
+      // Wait for UI to be ready
+      await ctx.getByText("Player X's turn").within(500).shouldExist();
 
       // Make some moves for a better screenshot
       const moves = [4, 0, 2, 6]; // Some X's and O's
       for (const move of moves) {
-        // Using cell IDs instead
-        await ctx.getByID(`cell${move}`).click();
-        await ctx.wait(200);
+        await ctx.getByID(`cell${move}`).within(200).click();
       }
 
+      // Wait for final state before screenshot
+      await ctx.getByText("Player X's turn").within(200).shouldExist();
+
       const screenshotPath = path.join(__dirname, 'screenshots', 'tictactoe-basic.png');
-      await ctx.wait(500);
       await tsyneTest.screenshot(screenshotPath);
       console.log(`📸 Screenshot saved: ${screenshotPath}`);
     });


### PR DESCRIPTION
…tests

Converted fixed delays to intelligent polling patterns per LLM.md guidance:
- Use within(ms).shouldExist() for waiting on UI elements to appear
- Use within(ms).click() for polling element availability before clicking
- Retain only one ctx.wait(1000) for headed mode visual inspection

Tests modified: tictactoe.test.ts, tictactoe-high-contrast.test.ts, tictactoe-mespeak.test.ts, tictactoe-accessible.test.ts

This reduces total test wait time by converting ~68 fixed wait calls into efficient polling that exits immediately when conditions are met.